### PR TITLE
Deleted link to Project guide; info is now in FAQ

### DIFF
--- a/data/configs/ospool.yml
+++ b/data/configs/ospool.yml
@@ -5,7 +5,6 @@ nav:
       - "Computation on the Open Science Pool ": overview/account_setup/is-it-for-you.md
       - "Registration and Login for OSG Connect ": overview/account_setup/registration-and-login.md
       - "Generate SSH Keys and Activate Your OSG Login ": overview/account_setup/generate-add-sshkey.md
-      - "Join and Use a Project in OSG Connect ": overview/account_setup/starting-project.md
       - "Requesting an OSPool ap7.ospool.osg-htc.org Account": overview/account_setup/ap7-access.md
   - Support And Training Resources:
     - Get Help!:


### PR DESCRIPTION
Deleted:
 - "Join and Use a Project in OSG Connect ": overview/account_setup/starting-project.md