### PR TITLE
Fix GHA deprecation warnings (SOFTWARE-5354)

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
           fetch-depth: 0


### PR DESCRIPTION
Updates deprecated node.js 12 actions to node.js 16.