### PR TITLE
removing login04 login05 from docs

### DIFF
--- a/documentation/htc_workloads/managing_data/data-transfer.md
+++ b/documentation/htc_workloads/managing_data/data-transfer.md
@@ -7,7 +7,7 @@ ospool:
 
 # Data Staging and Transfer to Jobs¶
 
-Due to the distributed configuration of the OSG, more often than not, your jobs will need to bring along a copy (i.e. transfer a copy) of data, code, packages, software, etc. from the Access Point (e.g. login04.osgconnect.net) where the job is submitted to the OSPool execute node where the job will run. This requirement applies to all files that are needed to successfully execute and complete your job that do not otherwise exist on OSG execute servers. This guide describes where OSG Connect users can store files on OSG-operatated Access Points, and how to use these files within jobs. 
+Due to the distributed configuration of the OSG, more often than not, your jobs will need to bring along a copy (i.e. transfer a copy) of data, code, packages, software, etc. from the Access Point (e.g. ap20, ap21, or ap40) where the job is submitted to the OSPool execute node where the job will run. This requirement applies to all files that are needed to successfully execute and complete your job that do not otherwise exist on OSG execute servers. This guide describes where OSG Connect users can store files on OSG-operatated Access Points, and how to use these files within jobs. 
 
 Table of Contents: 
 [TOC]

--- a/documentation/htc_workloads/managing_data/data-transfer.md
+++ b/documentation/htc_workloads/managing_data/data-transfer.md
@@ -1,5 +1,3 @@
-The /public location is a mount of the OSG Connect origin filesystem. It is mounted to the OSG Connect login nodes only so that users can appropriately stage large job inputs or retrieve outputs via the login nodes.
-
 ---
 ospool:
   path: htc_workloads/managing_data/data-transfer.md
@@ -22,7 +20,7 @@ In general, users are responsible for managing data in these folders and for usi
 Prior to January 2023, OSG Connect users stored files in `/home` and `/public` directories. Users with accounts created prior to 2023 are highly encouraged to move files in `/public` to `/protected` to prepare for the eventual depreciation of `/public`. Users with accounts created in January 2023 and after should only use `/home` and `/protected`.
 
 # Uploading/Downloading Data to/from OSG-operated Access Points
-In general, common Unix tools such as rsync, scp, PuTTY, WinSCP, gFTP, etc. can be used to upload data from your computer or another server to your OSG Access Point (e.g. `login05.osgconnect.net`), or to download files from your OSG Access Point. Files should be uploaded/created and staged in `/home` or `/protected` for preparation to use in jobs. 
+In general, common Unix tools such as rsync, scp, PuTTY, WinSCP, gFTP, etc. can be used to upload data from your computer or another server to your OSG Access Point (e.g. `ap40.uw.osg-htc.org`), or to download files from your OSG Access Point. Files should be uploaded/created and staged in `/home` or `/protected` for preparation to use in jobs. 
 
 # Transferring Data To/From HTCondor Jobs
 Use the following table to determine where to stage input files for jobs and where to store output files from jobs:  

--- a/documentation/htc_workloads/managing_data/overview.md
+++ b/documentation/htc_workloads/managing_data/overview.md
@@ -120,34 +120,6 @@ publicly discoverable and accessible to anyone.
       </ul>
   <td>
 </tr>
-<tr>
-  <td>login04.osgconnect.net</td>
-  <td>Accessible to user only:
-      <ul>
-        <li><nobr>Local Path: <code>/protected/[USERNAME]</code></nobr></li>
-        <li><nobr>Base OSDF URL: <code>osdf:///osgconnect/protected/[USERNAME]</code></nobr></li>
-      </ul>
-      Public:
-      <ul>
-        <li><nobr>Local Path: <code>/public/[USERNAME]</code></nobr></li>
-        <li><nobr>Base OSDF URL: <code>osdf:///osgconnect/public/[USERNAME]</code></nobr></li>
-      </ul>
-  </td>
-</tr>
-<tr>
-  <td>login05.osgconnect.net</td>
-  <td>Accessible to user only:
-      <ul>
-        <li><nobr>Local Path: <code>/protected/[USERNAME]</code></nobr></li>
-        <li><nobr>Base OSDF URL: <code>osdf:///osgconnect/protected/[USERNAME]</code></nobr></li>
-      </ul>
-      Public:
-      <ul>
-        <li><nobr>Local Path: <code>/public/[USERNAME]</code></nobr></li>
-        <li><nobr>Base OSDF URL: <code>osdf:///osgconnect/public/[USERNAME]</code></nobr></li>
-      </ul>
-  </td>
-</tr>
 </table>
 
 To see how to use OSDF URLs in `transfer_input_files` and

--- a/documentation/htc_workloads/submitting_workloads/monitor_review_jobs.md
+++ b/documentation/htc_workloads/submitting_workloads/monitor_review_jobs.md
@@ -18,7 +18,7 @@ The default behavior of `condor_q` is to list all of a user's jobs currently in 
 ```
 $ condor_q
 
--- Schedd: login05.osgconnect.net : <192.170.227.146:9618?... @ 03/04/22 12:31:45
+-- Schedd: ap40.uw.osg-htc.org : <192.170.227.146:9618?... @ 03/04/22 12:31:45
 OWNER     BATCH_NAME  SUBMITTED    DONE   RUN    IDLE  TOTAL JOB_IDS
 alice ID: 21562536   3/4  12:31      _      _      5      5 21562536.0-4
 
@@ -37,7 +37,7 @@ Additionally, the flag `-nobatch` can be used to list individual jobs instead of
 ```
 $ condor_q alice -nobatch
 
--- Schedd: login05.osgconnect.net : <192.170.227.146:9618?... @ 03/04/22 12:52:22
+-- Schedd: ap40.uw.osg-htc.org : <192.170.227.146:9618?... @ 03/04/22 12:52:22
  ID          OWNER            SUBMITTED     RUN_TIME ST PRI SIZE CMD
 21562638.0   alice            3/4  12:52   0+00:00:00 I  0    0.0 soilModel.py parameter1.csv
 21562638.1   alice            3/4  12:52   0+00:00:00 I  0    0.0 soilModel.py parameter2.csv

--- a/documentation/htc_workloads/workload_planning/roadmap.md
+++ b/documentation/htc_workloads/workload_planning/roadmap.md
@@ -54,9 +54,9 @@ If your account is on the uw.osg-htc.org Access Points (e.g., accounts on ap40.u
 </details>
 
 <details>
-<summary>Log In to "OSG Connect" Access Points (e.g., login04.osgconnect.net)</summary>
+<summary>Log In to "OSG Connect" Access Points (e.g., ap20.uc.osg-htc.org)</summary>
 <br>
-If your account is on the (e.g., accounts on login04.osgconnect.net, login05.osgconnect.net), follow instructions in this guide for logging in:
+If your account is on the OSG Connect Access points (e.g., accounts on ap20.uc.osg-htc.org, ap21.uc.osg-htc.org), follow instructions in this guide for logging in:
 <a href="https://portal.osg-htc.org/documentation/overview/account_setup/connect-access/">Log In to OSG Connect Access Points</a>
 </details>
 

--- a/documentation/overview/account_setup/ap20-ap21-migration.md
+++ b/documentation/overview/account_setup/ap20-ap21-migration.md
@@ -3,34 +3,26 @@ ospool:
   path: overview/account_setup/ap20-ap21-migration.md
 ---
 
-**This guide is for users who are migrating from login04.osgconnect.net / login05.osgconnect.net
-to the new access points ap20.uc.osg-htc.org / ap21.uc.osg-htc.org**
+# Migrating to New Access Points From `login04`, `login05`
 
-We are replacing the login04/login05.osgconnect.net access points with
-new improved access points.  
-
-**All users with accounts on login04/login05
-must migrate to the new servers by Tuesday, August 1.**
-
-Our dedicated infrastructure team has put in considerable effort to
-improve the user experience. The new access points have larger and
-faster file systems as well as improved network connectivity (100Gb
-links), which will improve data handling capabilities. We are also
-moving to a newer version of Linux.
-
-To encourage a speedy migration, jobs on the new access points will have
-higher priority than jobs on the old access points.
+The `login04`/`login05.osgconnect.net` access points were replaced with
+new improved access points during July and August of 2023. If you did not 
+migrate your account or data during this time, you can likely still access 
+the new access points, following these steps. Please contact the facilitation 
+team with any questions. 
 
 # Migration Steps
 
 ## Step 1: Determine Your Assigned Access Point
 
-Your new access point assignment will be based on your current access point:
+Your new access point assignment will be based on your former access point:
 
  * If your current assigment is `login04.osgconnect.net`, your new access point
    will be `ap20.uc.osg-htc.org`
  * If your current assigment is `login05.osgconnect.net`, your new access point
    will be `ap21.uc.osg-htc.org`
+
+You can also see this information on your profile page on [osgconnect.net](https://www.osgconnect.net)
 
 ## Step 2: Set Up Multi Factor Authentication
 
@@ -40,43 +32,10 @@ When connecting to an access point via ssh, you will be asked to provide the
 generated 6 digit verification code when logging in. Please see detailed instructions
 [here](../connect-access/#add-multi-factor-authentication-to-your-web-profile).
 
-## Step 3: Migrate Data
-
-**You are responsible for migrating your own data from login04/login05 to the 
-new Access Points.** The filesystems from `login04.osgconnect.net` and `login05.osgconnect.net` 
-will be mounted **temporarily** on the new access points for ease of data transfer. 
-Please ensure that you have copied all data you need
-by the August 1st deadline.
-
-**Once logged in to the new access points**, you will find your files from login04/login05 at the following locations:
-
-  * Your old home directory under `/mnt/login04/home/[USERNAME]` or `/mnt/login05/home/[USERNAME]`
-  * Your old /public directory under `/mnt/public/[USERNAME]`
-  * Your old /protected directory under `/mnt/protected/[USERNAME]`
-
-We recommend you use `cp` or `rsync` to duplicate the data to the new locations. Your `$HOME`
-directory is still the primary location for jobs, so data you had in your old `$HOME`
-directory should likely just be copied to the new `$HOME`. 
-
-For example, the following commands would copy all your data from your $HOME directory
-on one of login04 or login05 to your home directory on your new access point, and
-data from the old /public and /protected into the new OSDF location. In the commands,
-please replace `NN` with 04 or 05, and make sure you run the commands on the new
-access point.
-
-```
-rsync -av /mnt/loginNN/home/$USER/. /home/$USER/.
-mkdir -p $DATA/old-public $DATA/old-protected
-rsync -av /mnt/public/$USER/. $DATA/old-public/.
-rsync -av /mnt/protected/$USER/. $DATA/old-protected/.
-```
-
-**After the migration deadline, all data will be deleted from login04 / login05 under `$HOME`, `/public`, and `/protected`**
-
-## Step 4 (If Needed): Modify Workflows to Use New Data Paths
+## Step 3 (If Needed): Modify Workflows to Use New Data Paths
 
 [OSDF](../../../htc_workloads/managing_data/overview/) locations have changed. We recommend
-that most data from the old `/public/` or `/protected/` folders move into the new access point-
+that most data from the old `/public/` or `/protected/` folders transition to the new access point-
 specific user-only areas (`/ospool/ap20/data/` or `/ospool/ap21/data` based on which access
 point you are assigned to). This will offer the the best performance. You will also 
 need to upload submit files and scripts to use these new data locations.  Consult the 
@@ -89,5 +48,4 @@ Facilitation team with any questions.
 We understand transitions may raise questions or difficulties. Should you require 
 any assistance, please feel free to reach out to us via email, or join one of 
 our [office hours sessions](../../../support_and_training/support/getting-help-from-RCFs/#virtual-office-hours )
-).  We are happy to walk through the migration steps online so that you have minimal
- interruptions to your work. 
+). 

--- a/documentation/overview/account_setup/connect-access.md
+++ b/documentation/overview/account_setup/connect-access.md
@@ -9,8 +9,8 @@ ospool:
 will be using the "OSG Connect" Access Points. Do not go through the steps of this 
 guide until advised to by a Research Computing Facilitator**
 
-To join and use the "OSG Connect" Access Points (`login04.osgconnect.net`, 
-`login05.osgconnect.net`), you will go through the following steps: 
+To join and use the "OSG Connect" Access Points (`ap20.uc.osg-htc.org`, 
+`ap21.uc.osg-htc.org`), you will go through the following steps: 
 
 1. Apply for an OSG Connect Access Point account 
 2. Have your account approved by an OSG Team member

--- a/documentation/overview/account_setup/registration-and-login.md
+++ b/documentation/overview/account_setup/registration-and-login.md
@@ -61,11 +61,10 @@ If your account is on the uw.osg-htc.org Access Points (e.g., accounts on ap40.u
 </details>
 
 <details>
-<summary>Log In to "OSG Connect" Access Points (e.g., login04.osgconnect.net)</summary>
+<summary>Log In to "OSG Connect" Access Points (e.g., ap20.uc.osg-htc.org)</summary>
 <br>
-If your account is on the (e.g., accounts on login04.osgconnect.net, login05.osgconnect.net), follow instructions in this guide for logging in: 
+If your account is on the OSG Connect Access points (e.g., accounts on ap20.uc.osg-htc.org, ap21.uc.osg-htc.org), follow instructions in this guide for logging in:
 <a href="https://portal.osg-htc.org/documentation/overview/account_setup/connect-access/">Log In to OSG Connect Access Points</a>
 </details>
-
 
 

--- a/documentation/software_examples/other_languages_tools/conda-tarball.md
+++ b/documentation/software_examples/other_languages_tools/conda-tarball.md
@@ -35,8 +35,8 @@ In this approach, we will create an entire software installation inside Minicond
 
 After logging into your access point, download the latest Linux [miniconda installer](https://docs.conda.io/en/latest/miniconda.html) and run it. For example, 
 
-      [alice@login05]$ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-      [alice@login05]$ sh Miniconda3-latest-Linux-x86_64.sh
+      [alice@ap00]$ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      [alice@ap00]$ sh Miniconda3-latest-Linux-x86_64.sh
       
 Accept the license agreement and default options. At the end, you can choose whether or not to “initialize Miniconda3 by running conda init?” 
 - If you enter "no", you would then run the **eval** command listed by the installer to “activate” Miniconda. If you choose “no” you’ll want to save this command so that you can reactivate the Miniconda installation when needed in the future. 
@@ -48,28 +48,28 @@ Accept the license agreement and default options. At the end, you can choose whe
 
 Make sure that you’ve activated the base Miniconda environment if you haven’t already. Your prompt should look like this:
 
-      (base)[alice@login05]$ 
+      (base)[alice@ap00]$ 
 To create an environment, use the `conda create` command and then activate the environment:
 
-      (base)[alice@login05]$ conda create -n env-name
-      (base)[alice@login05]$ conda activate env-name
+      (base)[alice@ap00]$ conda create -n env-name
+      (base)[alice@ap00]$ conda activate env-name
 Then, run the `conda install` command to install the different packages and software you want to include in the installation. How this should look is often listed in the installation examples for software (e.g. [Qiime2](https://docs.qiime2.org/2023.2/install/), [Pytorch](https://pytorch.org/get-started/locally/)).
 
-      (env-name)[alice@login05]$ conda install pkg1 pkg2
+      (env-name)[alice@ap00]$ conda install pkg1 pkg2
 Some Conda packages are only available via specific Conda channels which serve as repositories for hosting and managing packages. If Conda is unable to locate the requested packages using the example above, you may need to have Conda search other channels. More detail are available at [https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html.](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html)
 
 Packages may also be installed via `pip`, but you should only do this when there is no `conda` package available.
 
 Once everything is installed, deactivate the environment to go back to the Miniconda “base” environment.
 
-      (env-name)[alice@login05]$ conda deactivate
+      (env-name)[alice@ap00]$ conda deactivate
 For example, if you wanted to create an installation with `pandas` and `matplotlib` and call the environment `py-data-sci`, you would use this sequence of commands:
 
-      (base)[alice@login05]$ conda create -n py-data-sci
-      (base)[alice@login05]$ conda activate py-data-sci
-      (py-data-sci)[alice@login05]$ conda install pandas matplotlib
-      (py-data-sci)[alice@login05]$ conda deactivate
-      (base)[alice@login05]$ 
+      (base)[alice@ap00]$ conda create -n py-data-sci
+      (base)[alice@ap00]$ conda activate py-data-sci
+      (py-data-sci)[alice@ap00]$ conda install pandas matplotlib
+      (py-data-sci)[alice@ap00]$ conda deactivate
+      (base)[alice@ap00]$ 
 
 > ### More About Miniconda
 > See the [official conda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) for more information on creating and managing environments with **conda**.
@@ -77,17 +77,17 @@ For example, if you wanted to create an installation with `pandas` and `matplotl
 ### 3. Create Software Package
 Make sure that your job’s Miniconda environment is created, but deactivated, so that you’re in the “base” Miniconda environment:
 
-      (base)[alice@login05]$ 
+      (base)[alice@ap00]$ 
 Then, run this command to install the `conda pack` tool:
 
-      (base)[alice@login05]$ conda install -c conda-forge conda-pack
+      (base)[alice@ap00]$ conda install -c conda-forge conda-pack
 Enter `y` when it asks you to install.
 
 Finally, use `conda pack` to create a zipped tar.gz file of your environment (substitute the name of your conda environment where you see `env-name`), set the proper permissions for this file using `chmod`, and check the size of the final tarball:
 
-      (base)[alice@login05]$ conda pack -n env-name
-      (base)[alice@login05]$ chmod 644 env-name.tar.gz
-      (base)[alice@login05]$ ls -sh env-name.tar.gz
+      (base)[alice@ap00]$ conda pack -n env-name
+      (base)[alice@ap00]$ chmod 644 env-name.tar.gz
+      (base)[alice@ap00]$ ls -sh env-name.tar.gz
 When this step finishes, you should see a file in your current directory named `env-name.tar.gz`.
 
 ### 4. Check Size of Conda Environment Tar Archive
@@ -169,15 +169,15 @@ If you want a record of what is installed in your environment, or want to reprod
 
 To create an `environment.yml` file from your currently-activated environment, run
 
-      [alice@login05]$ conda env export > environment.yml
+      [alice@ap00]$ conda env export > environment.yml
 This `environment.yml` will pin the exact version of every dependency in your environment. This can sometimes be problematic if you are moving between platforms because a package version may not be available on some other platform, causing an “unsatisfiable dependency” or “inconsistent environment” error. A much less strict pinning is
 
-      [alice@login05]$ conda env export --from-history > environment.yml
+      [alice@ap00]$ conda env export --from-history > environment.yml
 which only lists packages that you installed manually, and **does not pin their versions unless you yourself pinned them during installation**. If you need an intermediate solution, it is also possible to manually edit `environment.yml` files; see the [conda environment documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#) for more details about the format and what is possible. In general, exact environment specifications are simply not guaranteed to be transferable between platforms (e.g., between Windows and Linux). **We strongly recommend using the strictest possible pinning available to you**.
 
 To create an environment from an `environment.yml` file, run
 
-      [alice@login05]$ conda env create -f environment.yml
+      [alice@ap00]$ conda env create -f environment.yml
 By default, the name of the environment will be whatever the name of the source environment was; you can change the name by adding a `-n \<name>` option to the `conda env create` command.
 
 If you use a source control system like `git`, we recommend checking your `environment.yml` file into source control and making sure to recreate it when you make changes to your environment. Putting your environment under source control gives you a way to track how it changes along with your own code.


### PR DESCRIPTION
Removing all references to login04/login05 and updating the transition guide a bit. 