### PR TITLE
GPU updates, new examples

### DIFF
--- a/data/configs/ospool.yml
+++ b/data/configs/ospool.yml
@@ -47,7 +47,7 @@ nav:
       - "Monitor and Review Jobs With condor_q and condor_history": htc_workloads/submitting_workloads/monitor_review_jobs.md  
       - "Troubleshooting Job Errors": htc_workloads/submitting_workloads/tutorial-error101/README.md
     - Considerations For Specific Resource Needs:
-      - "Using GPUs on the OSPool": htc_workloads/specific_resource/gpu-jobs.md
+      - "GPU Jobs": htc_workloads/specific_resource/gpu-jobs.md
       - "Checkpointing Jobs": htc_workloads/submitting_workloads/checkpointing-on-OSPool.md
       - "Large Memory Jobs": htc_workloads/specific_resource/large-memory-jobs.md
       - "Multicore Jobs": htc_workloads/specific_resource/multicore-jobs.md
@@ -61,6 +61,9 @@ nav:
       - "Quickstart-Submit Example HTCondor Jobs": htc_workloads/submitting_workloads/tutorial-quickstart/README.md
       - "Organizing and Submitting HTC Workloads": htc_workloads/submitting_workloads/tutorial-organizing/README.md
       - "Finding OSG Locations": htc_workloads/submitting_workloads/tutorial-osg-locations/README.md
+    - Artificial Intelligence:
+      - "scikit-learn": software_examples/ai/scikit-learn.md
+      - "TensorFlow": software_examples/ai/tensorflow.md
     - Python:
       - "Run Python Scripts on the OSPool ": software_examples/python/manage-python-packages.md
       - "Scaling Up With HTCondor’s Queue Command": software_examples/python/tutorial-ScalingUp-Python/README.md
@@ -78,8 +81,6 @@ nav:
     - Julia and Java:
       - "Using Julia on the OSPool ": software_examples/other_languages_tools/julia-on-osg.md
       - "Using Java in Jobs ": software_examples/other_languages_tools/java-on-osg.md
-    - Machine Learning:
-      - "Working with Tensorflow, GPUs, and containers": software_examples/machine_learning/tutorial-tensorflow-containers/README.md
     - Bioinformatics:
       - "High-Throughput BLAST": software_examples/bioinformatics/tutorial-blast-split/README.md
       - "High-Throughput BWA Read Mapping": software_examples/bioinformatics/tutorial-bwa/README.md

--- a/data/docs/ospool/software_examples/ai/scikit-learn.md
+++ b/data/docs/ospool/software_examples/ai/scikit-learn.md
@@ -1,0 +1,1 @@
+../../../../../documentation/software_examples/ai/scikit-learn.md

--- a/data/docs/ospool/software_examples/ai/tensorflow.md
+++ b/data/docs/ospool/software_examples/ai/tensorflow.md
@@ -1,0 +1,1 @@
+../../../../../documentation/software_examples/ai/tensorflow.md

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -66,7 +66,7 @@ in order to access the greatest amount of computing capacity.**
     executable = run_gpu_job.py
     #arguments = 
    
-    # specify both general requirements and gpu requirements 
+    # specify both general requirements and gpu requirements if there are any
     requirements = True
     require_gpus = (Capability > 7.5)
     

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -37,7 +37,7 @@ be useful:
 
   * `Capability`: this is NOT the GPU library, but rather a measure of the GPU's "Compute Capability," which is relted to hardware generation
   * `DriverVersion`: maximum version of the GPU libraries that can be supported
-  * `GlobalMemoryMb`: amount of GPU memory available on the GPU device
+  * `GlobalMemoryMB`: amount of GPU memory available on the GPU device in megabytes (MB)
 
 If you want a certain type or family of GPUs, we usually recommend using the GPU's 
 'Compute Capability', known as the `Capability` by HTCondor. An A100 GPU has a 

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -3,15 +3,18 @@ ospool:
   path: htc_workloads/specific_resource/gpu-jobs.md
 ---
 
-Using GPUs on the OSPool 
-====================================
+GPU Jobs
+========
 
+GPUs (Graphical Processing Units) are a special kind of computer
+processor that are optimized for running very large numbers of simple
+calculations in parallel, which often can be applied to problems related
+to image processing or machine learning. Well-crafted GPU programs for
+suitable applications can outperform implementations running on CPUs
+by a factor of ten or more, but only when the program is written and
+designed explicitly to run on GPUs using special libraries like CUDA.
 
-
-The Open Science Pool has an increasing number of GPUs available to 
-run jobs. 
-
-# Requesting GPUs
+## Requesting GPUs
 
 To request a GPU for your HTCondor job, you can use the 
 HTCondor *request_gpus* attribute in your submit file (along 
@@ -25,73 +28,93 @@ attributes). For example:
 
 Users can request one or multiple GPU cores on a single GPU machine.
 
+### Specific GPU Requests
 
-## Specific GPU Requests
+If your software or code requires a certain type of GPU, or has some
+other special requirement, there is a special submit file line to
+request these capabilities, `require_gpus`. A few attributes that may
+be useful: 
 
-HTCondor records different GPU attributes that can be used to select 
-specific types of GPU devices. A few attributes that may be useful: 
+  * `Capability`: this is NOT the GPU library, but rather a measure of the GPU's "Compute Capability"
+  * `DriverVersion`: maximum version of the GPU libraries that can be supported
+  * `GlobalMemoryMb`: amount of GPU memory available on the GPU device
 
-* `GPUs_Capability`: this is NOT the GPU library, but rather a measure of the GPU's "Compute Capability"
-* `GPUs_DriverVersion`: maximum version of the GPU libraries that can be supported
-* `GPUs_GlobalMemoryMb`: amount of GPU memory available on the GPU device
-
-Any of the attributes above can be used in the submit file's `requirements` line to 
-select a specific kind of GPU. For 
-example, to request a GPU with more than 8GB of GPU memory, one could use: 
-
-    requirements = (GPUs_GlobalMemoryMb >= 8192)
-    
 If you want a certain type or family of GPUs, we usually recommend using the GPU's 
-'Compute Capability', known as the `GPUs_Capability` by HTCondor. An A100 GPU has a 
+'Compute Capability', known as the `Capability` by HTCondor. An A100 GPU has a 
 Compute Capability of 8.0, so if you wanted to run on an A100 GPU specifically, 
 the submit file requirement would be: 
 
-    requirements = (GPUs_Capability == 8.0)
+    require_gpus = (Capability >= 8.0)
+
+Multiple requirements can be specified by using && statements:
+
+    require_gpus = (Capability >= 7.5) && (GlobalMemoryMb >= 11000)
 
 **Note that the more requirements you include, the fewer resources will be available 
 to you! It's always better to set the minimal possible requirements (ideally, none!) 
 in order to access the greatest amount of computing capacity.**
 
-# Available GPUs
+### Sample Submit File
 
-## Capacity
+    universe = container
+    container_image = /cvmfs/singularity.opensciencegrid.org/htc/tensorflow:1.3
 
-There are multiple OSPool contributors providing GPUs on a regular basis to the OSPool. 
-Some of these contributors will make their GPUs available only when there is demand 
-in the job queue, so after initial small-scale job testing, we strongly recommend 
-submitting a signficant batch of test jobs to explore 
-how much throughput you can get in the system as a whole. 
+    log = job_$(Cluster)_$(Process).log
+    error = job_$(Cluster)_$(Process).err
+    output = job_$(Cluster)_$(Process).out
+    
+    executable = run_gpu_job.py
+    #arguments = 
+   
+    # specify both general requirements and gpu requirements 
+    requirements = True
+    require_gpus = (Capability > 7.5)
+    
+    request_gpus = 1
+    request_cpus = 1
+    request_memory = 4GB
+    request_disk = 4GB
+    
+    queue 1
 
-Also, **some members of the OSPool will only run GPU jobs if the job 
-uses a container** (see note about software below). 
+## Available GPUs
 
-## GPU Types
+### Capacity
 
-Because the composition of the OSPool can change from day to day, 
-we do not know exactly what specific GPUs are
-available at any given time. Based on previous GPU job executions, 
-you might land on one of the following types of GPUs:
+There are multiple OSPool contributors providing GPUs on a regular
+basis to the OSPool. Some of these contributors will make their GPUs
+available only when there is demand in the job queue, so after initial
+small-scale job testing, we strongly recommend submitting a signficant
+batch of test jobs to explore how much throughput you can get in the
+system as a whole.
 
-* GeForce GTX 1080 Ti (GPUs\_Capability: 6.1)
-* V100 (GPUs\_Capability: 7.0)
-* GeForce GTX 2080 Ti (GPUs\_Capability: 7.5)
-* Quadro RTX 6000 (GPUs\_Capability: 7.5)
-* A100 (GPUs\_Capability: 8.0)
-* A40 (GPUs\_Capability: 8.6)
-* GeForce RTX 3090 (GPUs\_Capability: 8.6)
+### GPU Types
 
-# Software and Data Considerations
+Because the composition of the OSPool can change from day to day, we do
+not know exactly what specific GPUs are available at any given time.
+Based on previous GPU job executions, you might land on one of the
+following types of GPUs:
 
-## Software for GPUs
+* GeForce GTX 1080 Ti (Capability: 6.1)
+* V100 (Capability: 7.0)
+* GeForce GTX 2080 Ti (Capability: 7.5)
+* Quadro RTX 6000 (Capability: 7.5)
+* A100 (Capability: 8.0)
+* A40 (Capability: 8.6)
+* GeForce RTX 3090 (Capability: 8.6)
+
+## Software and Data Considerations
+
+### Software for GPUs
 
 For GPU-enabled machine learning libraries, we recommend using 
 containers to set up your software for jobs: 
 
-  * [Using Containers on the OSPool](../../../htc_workloads/using_software/available-containers-list/)
+  * [Containers - Apptainer/Singularity](../../../htc_workloads/using_software/containers-singularity/)
   * [Sample TensorFlow GPU Container Image Definition](https://github.com/opensciencegrid/osgvo-tensorflow-gpu/blob/master/Dockerfile)
   * [TensorFlow Example Job](../../../software_examples/machine_learning/tutorial-tensorflow-containers/)
 
-## Data Needs for GPU Jobs
+### Data Needs for GPU Jobs
 
 As with any kind of job submission, check your data sizes (per job) before submitting 
 jobs and choose the appropriate file transfer method for your data. 

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -40,7 +40,7 @@ be useful:
   * `GlobalMemoryMB`: amount of GPU memory available on the GPU device in megabytes (MB)
 
 If you want a certain type or family of GPUs, we usually recommend using the GPU's 
-'Compute Capability', known as the `Capability` by HTCondor. An A100 GPU has a 
+'Compute Capability', known as the `Capability` by HTCondor. For example, an NVIDIA A100 GPU has a 
 Compute Capability of 8.0, so if you wanted to run on an A100 GPU specifically, 
 the submit file requirement would be: 
 

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -114,10 +114,6 @@ software containers to set up your software for jobs:
   * [Sample TensorFlow GPU Container Image Definition](https://github.com/opensciencegrid/osgvo-tensorflow-gpu/blob/master/Dockerfile)
   * [TensorFlow Example Job](../../../software_examples/machine_learning/tutorial-tensorflow-containers/)
 
-### Data Needs for GPU Jobs
-
-As with any kind of job submission, check your data sizes (per job) before submitting 
-jobs and choose the appropriate file transfer method for your data. 
 
 See our [Data Staging and Transfer guide](../../../htc_workloads/managing_data/osgconnect-storage/) for
 details and contact the Research Computing Facilitation team with questions.

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -35,7 +35,7 @@ other special requirement, there is a special submit file line to
 request these capabilities, `require_gpus`. A few attributes that may
 be useful: 
 
-  * `Capability`: this is NOT the GPU library, but rather a measure of the GPU's "Compute Capability"
+  * `Capability`: this is NOT the GPU library, but rather a measure of the GPU's "Compute Capability," which is relted to hardware generation
   * `DriverVersion`: maximum version of the GPU libraries that can be supported
   * `GlobalMemoryMb`: amount of GPU memory available on the GPU device
 

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -44,7 +44,7 @@ If you want a certain type or family of GPUs, we usually recommend using the GPU
 Compute Capability of 8.0, so if you wanted to run on an A100 GPU specifically, 
 the submit file requirement would be: 
 
-    require_gpus = (Capability >= 8.0)
+    require_gpus = (Capability == 8.0)
 
 Multiple requirements can be specified by using && statements:
 

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -67,7 +67,7 @@ in order to access the greatest amount of computing capacity.**
     #arguments = 
    
     # specify both general requirements and gpu requirements if there are any
-    requirements = True
+#    requirements =
     require_gpus = (Capability > 7.5)
     
     request_gpus = 1

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -48,7 +48,7 @@ the submit file requirement would be:
 
 Multiple requirements can be specified by using && statements:
 
-    require_gpus = (Capability >= 7.5) && (GlobalMemoryMb >= 11000)
+    require_gpus = (Capability >= 7.5) && (GlobalMemoryMB >= 11000)
 
 **Note that the more requirements you include, the fewer resources will be available 
 to you! It's always better to set the minimal possible requirements (ideally, none!) 

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -86,7 +86,7 @@ basis to the OSPool. Some of these contributors will make their GPUs
 available only when there is demand in the job queue, so after initial
 small-scale job testing, we strongly recommend submitting a signficant
 batch of test jobs to explore how much throughput you can get in the
-system as a whole.
+system as a whole. As a reminder, because the OSPool is dynamic, the more jobs submitted requesting GPUs, the more GPU machines will be pulled into the OSPool as execution points.
 
 ### GPU Types
 

--- a/documentation/htc_workloads/specific_resources/gpu-jobs.md
+++ b/documentation/htc_workloads/specific_resources/gpu-jobs.md
@@ -108,7 +108,7 @@ following types of GPUs:
 ### Software for GPUs
 
 For GPU-enabled machine learning libraries, we recommend using 
-containers to set up your software for jobs: 
+software containers to set up your software for jobs: 
 
   * [Containers - Apptainer/Singularity](../../../htc_workloads/using_software/containers-singularity/)
   * [Sample TensorFlow GPU Container Image Definition](https://github.com/opensciencegrid/osgvo-tensorflow-gpu/blob/master/Dockerfile)

--- a/documentation/software_examples/ai/scikit-learn.md
+++ b/documentation/software_examples/ai/scikit-learn.md
@@ -56,7 +56,7 @@ An example scikit-learn machine learning executable is:
     executable = run-scikit-learn.py
     #arguments = 
    
-    # specify both general requirements and gpu requirements 
+    # specify both general requirements and gpu requirements if there are any
     requirements = True
     
     request_gpus = 0

--- a/documentation/software_examples/ai/scikit-learn.md
+++ b/documentation/software_examples/ai/scikit-learn.md
@@ -7,8 +7,8 @@ ospool:
 
 scikit-learn is a machine learning toolkit for Python.
 
-Below you will find an example on how to use an OSG provided
-scikit-learn image. However, it is good to keep in mind that
+Below you will find an example on how to use an OSG-provided software container that contains 
+scikit-learn. However, it is good to keep in mind that
 you have two options when it comes to integrating your own
 code:
 

--- a/documentation/software_examples/ai/scikit-learn.md
+++ b/documentation/software_examples/ai/scikit-learn.md
@@ -22,7 +22,10 @@ Containers are detailed in our general documentation:
 
   * [Containers - Apptainer/Singularity](../../../htc_workloads/using_software/containers-singularity/)
 
-## Python Code
+## Scikit-learn Python Code
+
+An example scikit-learn machine learning executable is:
+
 
     #!/usr/bin/env python3
     

--- a/documentation/software_examples/ai/scikit-learn.md
+++ b/documentation/software_examples/ai/scikit-learn.md
@@ -66,5 +66,3 @@ An example scikit-learn machine learning executable is:
     request_disk = 4GB
     
     queue 1
-
-

--- a/documentation/software_examples/ai/scikit-learn.md
+++ b/documentation/software_examples/ai/scikit-learn.md
@@ -57,7 +57,8 @@ An example scikit-learn machine learning executable is:
     #arguments = 
    
     # specify both general requirements and gpu requirements if there are any
-    requirements = True
+    # requirements = True
+    # require_gpus = 
     
     request_gpus = 0
     request_cpus = 1

--- a/documentation/software_examples/ai/scikit-learn.md
+++ b/documentation/software_examples/ai/scikit-learn.md
@@ -1,0 +1,66 @@
+---
+ospool:
+  path: software_examples/ai/scikit-learn.md
+---
+
+# scikit-learn
+
+scikit-learn is a machine learning toolkit for Python.
+
+Below you will find an example on how to use an OSG provided
+scikit-learn image. However, it is good to keep in mind that
+you have two options when it comes to integrating your own
+code:
+
+  1. If the code is simple, send it with the job (this is what the
+     example uses)
+  2. For more complex codes, consider extending the provided
+     containers and integrate the code into the new custom
+     container
+
+Containers are detailed in our general documentation:
+
+  * [Containers - Apptainer/Singularity](../../../htc_workloads/using_software/containers-singularity/)
+
+## Python Code
+
+    #!/usr/bin/env python3
+    
+    # example adopted from https://scikit-learn.org/stable/tutorial/basic/tutorial.html
+    
+    from sklearn import datasets
+    from sklearn import svm
+    
+    iris = datasets.load_iris()
+    digits = datasets.load_digits()
+    
+    # learning
+    clf = svm.SVC(gamma=0.001, C=100.)
+    clf.fit(digits.data[:-1], digits.target[:-1])
+    
+    # predicting
+    print(clf.predict(digits.data[-1:]))
+
+## Submit File
+
+    universe = container
+    container_image = /cvmfs/singularity.opensciencegrid.org/htc/scikit-learn:1.3
+
+    log = job_$(Cluster)_$(Process).log
+    error = job_$(Cluster)_$(Process).err
+    output = job_$(Cluster)_$(Process).out
+    
+    executable = run-scikit-learn.py
+    #arguments = 
+   
+    # specify both general requirements and gpu requirements 
+    requirements = True
+    
+    request_gpus = 0
+    request_cpus = 1
+    request_memory = 4GB
+    request_disk = 4GB
+    
+    queue 1
+
+

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -104,4 +104,9 @@ To run this TensorFlow script, create an HTCondor submit file to tell HTCondor h
     
     queue 1
 
+## Run TensorFlow
+
+Since we have prepared our executable, submit file, and are using an OSG-provided TensorFlow container, we are ready to submit this job to run on one of the OSPool GPU machines. 
+
+To submit this job to run, type `condor_submit TensorFlow.submit`. The status of your job can be checked at any time by running `condor_q`. 
 

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -79,7 +79,7 @@ An example TensorFlow executable that builds a machine learning model and evalua
     model.evaluate(x_test,  y_test, verbose=2)
 
 
-## Submit File
+## HTCondor Submit File
 
 To run this TensorFlow script, create an HTCondor submit file to tell HTCondor how you would like it run on your behalf. An example HTCondor submit file for this job is below. Because TensorFlow is optimized to run with GPUs, make sure to tell HTCondor to assign your job to a GPU machine: 
 

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -88,8 +88,8 @@ containers are detailed in the general documentation:
     executable = run-tf.py
     #arguments = 
    
-    # specify both general requirements and gpu requirements 
-    requirements = True
+    # specify both general requirements and gpu requirements if needed
+    # requirements = True
     require_gpus = (Capability > 7.5)
     
     request_gpus = 1

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -81,6 +81,8 @@ An example TensorFlow executable that builds a machine learning model and evalua
 
 ## Submit File
 
+To run this TensorFlow script, create an HTCondor submit file to tell HTCondor how you would like it run on your behalf. An example HTCondor submit file for this job is below. Because TensorFlow is optimized to run with GPUs, make sure to tell HTCondor to assign your job to a GPU machine: 
+
     universe = container
     container_image = /cvmfs/singularity.opensciencegrid.org/htc/tensorflow:2.15
 

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -3,6 +3,8 @@ ospool:
   path: software_examples/ai/tensorflow.md
 ---
 
+The OSPool enables AI (Artificial Intelligence) workloads by providing
+ access to GPUs and custom software stacks via containers. An example of this support is the machine learning platform TensorFlow.
 # TensorFlow
 
 [https://www.tensorflow.org/](https://www.tensorflow.org/) desribes TensorFlow as:

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -1,0 +1,103 @@
+---
+ospool:
+  path: software_examples/ai/tensorflow.md
+---
+
+# TensorFlow
+
+[https://www.tensorflow.org/](https://www.tensorflow.org/) desribes TensorFlow as:
+
+> TensorFlow is an open source software library for numerical
+> computation using data flow graphs. Nodes in the graph represent
+> mathematical operations, while the graph edges represent the
+> multidimensional data arrays (tensors) communicated between them. The
+> flexible architecture allows you to deploy computation to one or more
+> CPUs or GPUs in a desktop, server, or mobile device with a single
+> API. TensorFlow was originally developed by researchers and engineers
+> working on the Google Brain Team within Google's Machine Intelligence
+> research organization for the purposes of conducting machine learning
+> and deep neural networks research, but the system is general enough to
+> be applicable in a wide variety of other domains as well.
+
+The OSPool enables AI (Artificial Intelligence) workloads by providing
+access to GPUs and custom software stacks via containers. Tensorflow
+is a good example here as the software is too complex to bundle up
+and ship with your job. Containers solve this problem by defining a
+full OS image, containing not only the complex software package, but
+dependencies and environment configuration as well. GPUs and
+containers are detailed in the general documentation:
+
+  * [GPU Jobs](../../../htc_workloads/specific_resource/gpu-jobs/)
+  * [Containers - Apptainer/Singularity](../../../htc_workloads/using_software/containers-singularity/)
+
+## Python Code
+
+    #!/usr/bin/env python3
+    
+    # example adopted from https://www.tensorflow.org/tutorials/quickstart/beginner
+    
+    import tensorflow as tf
+    print("TensorFlow version:", tf.__version__)
+    
+    # this will show that the GPU was found
+    tf.debugging.set_log_device_placement(True)
+    
+    # load a dataset
+    mnist = tf.keras.datasets.mnist
+    
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    x_train, x_test = x_train / 255.0, x_test / 255.0
+    
+    # build a machine learning model
+    model = tf.keras.models.Sequential([
+      tf.keras.layers.Flatten(input_shape=(28, 28)),
+      tf.keras.layers.Dense(128, activation='relu'),
+      tf.keras.layers.Dropout(0.2),
+      tf.keras.layers.Dense(10)
+    ])
+    
+    predictions = model(x_train[:1]).numpy()
+    
+    # convert to probabilities
+    tf.nn.softmax(predictions).numpy()
+    
+    # loss function
+    loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+    loss_fn(y_train[:1], predictions).numpy()
+    
+    # compile model
+    model.compile(optimizer='adam',
+                  loss=loss_fn,
+                  metrics=['accuracy'])
+    
+    # train
+    model.fit(x_train, y_train, epochs=5)
+    
+    # evaluate
+    model.evaluate(x_test,  y_test, verbose=2)
+
+
+## Submit File
+
+    universe = container
+    container_image = /cvmfs/singularity.opensciencegrid.org/htc/tensorflow:2.15
+
+    log = job_$(Cluster)_$(Process).log
+    error = job_$(Cluster)_$(Process).err
+    output = job_$(Cluster)_$(Process).out
+    
+    executable = run-tf.py
+    #arguments = 
+   
+    # specify both general requirements and gpu requirements 
+    requirements = True
+    require_gpus = (Capability > 7.5)
+    
+    request_gpus = 1
+    request_cpus = 1
+    request_memory = 4GB
+    request_disk = 4GB
+    
+    queue 1
+
+

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -21,12 +21,9 @@ The OSPool enables AI (Artificial Intelligence) workloads by providing
 > and deep neural networks research, but the system is general enough to
 > be applicable in a wide variety of other domains as well.
 
-The OSPool enables AI (Artificial Intelligence) workloads by providing
-access to GPUs and custom software stacks via containers. Tensorflow
-is a good example here as the software is too complex to bundle up
-and ship with your job. Containers solve this problem by defining a
-full OS image, containing not only the complex software package, but
-dependencies and environment configuration as well. GPUs and
+TensorFlow can be a complicated software to install as it requires many dependencies and specific environmental configurations. Software ontainers solve this problem by defining a
+full operating system image, containing not only the complex software package, but
+dependencies and environment configuration as well. Working with GPUs and
 containers are detailed in the general documentation:
 
   * [GPU Jobs](../../../htc_workloads/specific_resource/gpu-jobs/)

--- a/documentation/software_examples/ai/tensorflow.md
+++ b/documentation/software_examples/ai/tensorflow.md
@@ -29,7 +29,10 @@ containers are detailed in the general documentation:
   * [GPU Jobs](../../../htc_workloads/specific_resource/gpu-jobs/)
   * [Containers - Apptainer/Singularity](../../../htc_workloads/using_software/containers-singularity/)
 
-## Python Code
+## TensorFlow Python Code
+
+An example TensorFlow executable that builds a machine learning model and evaluates it is:
+
 
     #!/usr/bin/env python3
     


### PR DESCRIPTION
- Updated GPU guide to use the `require_gpu` attribute to select GPUs
- Removed prefixes in Capability and other related attributes
- Moved from old "Machine Learning" doc category, to the potentially more relevant "Artificial Intelligence" name
- Removed old tensorfow guide - this is outdated
- Added new tensorflow example
- Added new scikit-learn example