### PR TITLE
Renamed guide to remove the word "supported"

### DIFF
--- a/documentation/htc_workloads/using_software/available-containers-list.md
+++ b/documentation/htc_workloads/using_software/available-containers-list.md
@@ -3,7 +3,7 @@ ospool:
   path: htc_workloads/using_software/available-containers-list.md
 ---
 
-Existing OSPool-Supported Containers 
+Containers - Predefined List of Commonly Used Containers 
 ====================================
 
 This is list of commonly used containers in the Open Science Pool. These can be used


### PR DESCRIPTION
We "support" many containers beyond this list. I've attempted to rename the guide to imply that these are just commonly used containers that we provide/manage.