### PR TITLE
Continuing to fix pages with incorrect header hierarchy

### DIFF
--- a/documentation/PATh/htc_workloads/containers/containers.md
+++ b/documentation/PATh/htc_workloads/containers/containers.md
@@ -34,7 +34,7 @@ commands to start the container. Nor should the container image
 contain any entrypoint/cmd - the job is the command to be run in the
 container.
 
-### Exploring Images on the Access Points
+## Exploring Images on the Access Points
 
 Just like it is important to test your codes and jobs at a small scale,
 you should make sure that your container is working correctly. One way

--- a/documentation/PATh/htc_workloads/specific_resources/gpus.md
+++ b/documentation/PATh/htc_workloads/specific_resources/gpus.md
@@ -9,7 +9,7 @@ GPUs
 The PATh Facility has an increasing number of GPUs available to 
 run jobs. 
 
-# Requesting GPUs
+## Requesting GPUs
 
 To request a GPU for your HTCondor job, you can use the 
 HTCondor *request_gpus* attribute in your submit file (along 
@@ -49,15 +49,15 @@ the submit file requirement would be:
 to you! It's always better to set the minimal possible requirements (ideally, none!) 
 in order to access the greatest amount of computing capacity.**
 
-# Available GPUs
+### Available GPUs
 
 Description of the available CPUs can be found under the 
 [Facility Description](https://path-cc.io/facility/index.html#facility-description).
 Currently, A100 is the main GPU available.
 
-# Software and Data Considerations
+## Software and Data Considerations
 
-## Software for GPUs
+### Software for GPUs
 
 For GPU-enabled machine learning libraries, we recommend using 
 containers to set up your software for jobs: 

--- a/documentation/PATh/htc_workloads/submitting_workloads/checkpointing.md
+++ b/documentation/PATh/htc_workloads/submitting_workloads/checkpointing.md
@@ -8,7 +8,7 @@ Checkpointing Jobs
 
 
 
-# What is Checkpointing?
+## What is Checkpointing?
 
 Checkpointing is a technique that provides fault tolerance for a user's analysis. It consists of saving snapshots of a job's progress so the job can be restarted without losing its progress and having to restart from the beginning. We highly encourage checkpointing as a solution for long jobs. 
 
@@ -19,20 +19,20 @@ There are two types of checkpointing: exit driven and eviction driven. In a vast
 Note that not all software, programs, or code are capable of creating checkpoint files and knowing how to resume from them. Consult the manual for your software or program to determine if it supports checkpointing features. Some manuals will refer this ability as "checkpoint" features, as the ability to "resume" mid-analysis if a job is interrupted, or as "checkpoint/restart" capabilities. Contact a Research Computing Facilitator if you would like help determining if your software, program, or code is able to checkpoint. 
 
 
-# Why Checkpoint? 
+## Why Checkpoint? 
 
 Checkpointing allows a job to automatically resume from approximately where it left off instead of having to start over if interrupted. This behavior is advantageous for jobs limited by a maximum runtime policy. It is also advantageous for jobs submitted to backfill resources with no runtime guarantee (i.e. jobs on the OSPool) where the compute resources may also be more prone to hardware or networking failures.
 
 For example, checkpointing jobs that are limited by a runtime policy can enable HTCondor to exit a job and automatically requeue it to avoid hitting the maximum runtime limit. By using checkpointing, jobs circumvent hitting the maximum runtime limit and can run for extended periods of time until the completion of the analysis. This behavior avoids costly setbacks that may be caused by loosing results mid-way through an analysis due to hitting a runtime limit. 
 
-# Process of Exit Driven Checkpointing
+## Process of Exit Driven Checkpointing
 
 Using exit driven checkpointing, a job is specified to time out after a user-specified amount of time with an exit code value of 85 (more on this below). Upon hitting this time limit, HTCondor transfers any checkpoint files listed in the submit file attribute `transfer_checkpoint_files` to a directory called `/spool`. This directory acts as a storage location for these files in case the job is interrupted. HTCondor then knows that jobs with exit code `85` should be automatically requeued, and will transfer the checkpoint files in `/spool` to your job's working directory prior to restarting your executable.
 
 The process of exit driven checkpointing relies heavily on the use of exit codes to determine the next appropriate steps for HTCondor to take with a job. In general, exit codes are used to report system responses, such as when an analysis is running, encountered an error, or successfully completes. HTCondor recognizes exit code `85` as checkpointing jobs and therefore will know to handle these jobs differently than non-checkpoiting jobs.
 
 
-# Requirements for Exit Driven Checkpointing
+## Requirements for Exit Driven Checkpointing
 
 Requirements for your code or software: 
 
@@ -45,7 +45,7 @@ Requirements for your code or software:
 Contact a Research Computing Facilitator for help determining if your job is capable of using checkpointing.  
 
 
-# Changes to the Submit File
+## Changes to the Submit File
 
 Several modifications to the submit file are needed to enable HTCondor's checkpointing feature. 
 
@@ -80,7 +80,7 @@ An example submit file for an exit driven checkpointing job looks like:
     queue 1
 
 
-# Example Wrapper Script for Checkpointing Job
+## Example Wrapper Script for Checkpointing Job
 
 As previously described, it may be necessary to use a wrapper script to tell your job when and how to exit as it checkpoints. An example of a wrapper script that tells a job to exit every 4 hours looks like: 
 
@@ -131,13 +131,13 @@ Let's take a moment to understand what each section of this wrapper script is do
 The ideal timeout frequency for a job is every 1-5 hours with a maximum of 10 hours. For jobs that checkpoint and timeout in under an hour, it is possible that a job may spend more time with checkpointing procedures than moving forward with the analysis. After 10 hours, the likelihood of a job being inturrupted on the OSPool is higher. 
 
 
-# Checking the Progress of Checkpointing Jobs
+## Checking the Progress of Checkpointing Jobs
 
 It is possible to investigate checkpoint files once they have been transferred to `/spool`.
 
 You can explore the checkpointed files in `/spool` by navigating to `/home/condor/spool` on an OSG Connect login node. The directories in this folder are the last four digits of a job's cluster ID with leading zeros removed. Sub folders are labeled with the process ID for each job. For example, to investigate the checkpoint files for `17870068.220`, the files in `/spool` would be found in folder `68` in a subdirectory called `220`.
 
 
-# More Information
+### More Information
 
 More information on checkpointing HTCondor jobs can be found in HTCondor's manual: https://htcondor.readthedocs.io/en/latest/users-manual/self-checkpointing-applications.html This documentation contains additional features available to checkpointing jobs, as well as additional examples such as a python checkpointing job.

--- a/documentation/PATh/htc_workloads/submitting_workloads/submit-multiple-jobs.md
+++ b/documentation/PATh/htc_workloads/submitting_workloads/submit-multiple-jobs.md
@@ -6,7 +6,7 @@ path:
 Easily Submit Multiple Jobs 
 ====================================
 
-# Overview
+## Overview
 
 HTCondor has several convenient features for streamlining high-throughput 
 job submission. This guide provides several examples 
@@ -19,7 +19,7 @@ Many options exist for streamlining your submission of multiple jobs,
 and this guide only covers a few examples of what is truly possible with 
 HTCondor.
 
-# Submit Multiple Jobs Using `queue`
+## Submit Multiple Jobs Using `queue`
 
 All HTCondor submit files require a `queue` attribute (which must also be 
 the last line of the submit file). By default, `queue` will submit one job, but 

--- a/documentation/PATh/htc_workloads/using_data/data-transfer.md
+++ b/documentation/PATh/htc_workloads/using_data/data-transfer.md
@@ -5,13 +5,13 @@ path:
 
 # Data Staging and Transfer to Jobs
 
-# Overview
+## Overview
 
 As a distributed system, jobs in the PATh Facility can run in different physical locations, where the computers that are executing jobs don't have direct access to the files placed on the Access Point (e.g. in a `/home` directory on `ap1.facility.path-cc.io`). In order to run on this kind of distributed system, jobs need to "bring along" the data, code, packages, and other files from the Access Point (where the job is submitted) to the PATh Facility execute points (where the job will run).  HTCondor's file transfer tools and plugins make this possible; input and output files are specified as part of the job submission and then moved to and from the execution location. 
 
 This guide describes where to place files on PATh Facility Access Points, and how to use these files within jobs. 
 
-# Data Spaces on the PATh Facility
+## Data Spaces on the PATh Facility
 
 There are two spaces for placing files on the PATh Facility Access Point, and each has a corresponding transfer method for referencing files in the submit file. 
 
@@ -48,7 +48,7 @@ The examples above are both specific to a single user. If you need to share file
 with other members of your group or project, or need to make files publicly available, 
 please contact the facilitation team to arrange a project folder: [support@path-cc.io](mailto:support@path-cc.io)
 
-# Transferring Data To/From HTCondor Jobs
+## Transferring Data To/From HTCondor Jobs
 
 **Regardless of where data is placed, jobs should only be submitted with `condor_submit` from `/home`.**
 
@@ -135,28 +135,28 @@ Some examples:
 		OSDF_LOCATION = osdf:///path-facility/data/<username>
 		transfer_output_remaps = "file1.txt = $(OSDF_LOCATION)/file1.txt; file2.txt = $(OSDF_LOCATION)/file2.txt; file3.txt = $(OSDF_LOCATION)/file3.txt"
 
-# Moving Data to/from PATh Facility Access Points
+## Moving Data to/from PATh Facility Access Points
 
 In general, common Unix tools such as rsync, scp, PuTTY, WinSCP, gFTP, etc. can be used to upload data from your computer or another server to your PATh Facility Access Point or to download files. Files should be uploaded/created and staged in `/home` or `/path-facility` for preparation to use in jobs (as described above). 
 
-# Check Your Quota and Available Space
+## Check Your Quota and Available Space
 
-## Check your `/home` quota
+### Check your `/home` quota
 
 To check your home quota and usage, run: 
 
 	$ quota -vs
 
-##  Check your `/path-facility/data` quota
+###  Check your `/path-facility/data` quota
 
 For now, contact the facilitation team if you are unsure what your `/path-facility/data` 
 quota is. 
 
-## Request Quota Increase
+### Request Quota Increase
 
 Contact us at support@path-cc.io if you think you need a quota increase. We have space for substantial workloads when communicated with in advance. 
 
-# Data Policies
+## Data Policies
 
 In general, users are responsible for managing data and for using appropriate mechanisms for delivering data to/from jobs. Each space for data is controlled with a quota and should be treated as temporary storage for *active* job execution. The PATh Facility has no routine backup of data in these locations, and users should remove old data after jobs complete. 
 

--- a/documentation/PATh/htc_workloads/using_software/conda-environments.md
+++ b/documentation/PATh/htc_workloads/using_software/conda-environments.md
@@ -8,7 +8,7 @@ Using conda to Run Python on the PATh Facility
 
 The Anaconda/Miniconda distribution of Python is a common tool for installing and managing Python-based software and other tools. 
 
-# Overview
+## Overview
 
 When should you use Miniconda as an installation method in the PATh Facility?
 * Your software has specific conda-centric installation instructions.
@@ -25,7 +25,7 @@ To create the smallest, most portable Python installation possible, we recommend
 
 To use a Miniconda installation on the PATh Facility, create your installation environment on the Access Point and send a zipped version to your jobs.
 
-# Install Miniconda and Package for Jobs
+## Install Miniconda and Package for Jobs
 
 This section of the guide goes through the steps needed to create a software installation inside Miniconda and then use a tool called `conda pack` to package it up for running jobs.
 
@@ -130,7 +130,7 @@ In your submit file, make sure to have the following:
 * Your executable should be the the bash script you created in [step 5](#5-create-a-job-executable).
 * Remember to transfer your Python script and the environment `tar.gz` file to the job. If the `tar.gz` file is larger than 100MB, please use the `stash:///` file delivery mechanism as described above. 
       
-# Specifying Exact Dependency Versions
+## Specifying Exact Dependency Versions
 
 An important part of improving reproducibility and consistency between runs is to ensure that you use the correct/expected versions of your dependencies.
 

--- a/documentation/PATh/overview/account_setup/getting-started.md
+++ b/documentation/PATh/overview/account_setup/getting-started.md
@@ -70,7 +70,7 @@ If you have already applied for a credit allocation at the time of requesting
 an account, let us know that information and we will add credits to your 
 project account. 
 
-# Reach Out
+## Reach Out
 
 If you're not sure where to start or are not sure if the PATh Facility is for you, 
 we recommend either filling out the User 

--- a/documentation/PATh/overview/references/credit-account-charges.md
+++ b/documentation/PATh/overview/references/credit-account-charges.md
@@ -11,7 +11,7 @@ are defined by a combination of per-job cores and memory request, while GPU Cred
 of per-job GPU, CPU, and memory request.
 
 
-# CPU Credits
+## CPU Credits
 
 |Cores per job|Credit charge per core hour|
 |--- |--- |
@@ -49,7 +49,7 @@ use 0.375 * 112 = 42 credits total for memory and 1.2 * 8 = 9.6 credits for
 CPU.
 
 
-# GPU Credits
+## GPU Credits
 
 |GPUs per job|Credit charge per GPU hour|
 |--- |--- |


### PR DESCRIPTION
Found on 2/22/24 and fixed:
/PATh/htc_workloads/containers/containers.md
/PATh/htc_workloads/specific_resources/gpus.md
/PATh/htc_workloads/submitting_workloads/checkpointing.md
/PATh/htc_workloads/submitting_workloads/submit-multiple-jobs.md
/PATh/htc_workloads/using_data/data-transfer.md
/PATh/htc_workloads/using_software/conda-environments.md
/PATh/overview/account_setup/getting-started.md