### PR TITLE
Cleaning up various formatting of the Hello World htcondor guide

### DIFF
--- a/data/configs/ospool.yml
+++ b/data/configs/ospool.yml
@@ -24,7 +24,7 @@ nav:
     - How to Use the OSPool:
       - "Roadmap to HTC Workload Submission": htc_workloads/workload_planning/roadmap.md
     - HTC Workload Planning, Testing, and Scaling Up:
-      - "Overview: Submit OSPool Jobs using HTCondor": htc_workloads/workload_planning/htcondor_job_submission.md
+      - "Overview: Submit Jobs to the OSPool using HTCondor": htc_workloads/workload_planning/htcondor_job_submission.md
       - "Determining the Amount of Resources to Request in a Submit File ": htc_workloads/workload_planning/preparing-to-scale-up.md
       - "Easily Submit Multiple Jobs": htc_workloads/submitting_workloads/submit-multiple-jobs.md
       - "Convert your workflow from Slurm to HTCondor": htc_workloads/submitting_workloads/Slurm_to_HTCondor.md

--- a/documentation/htc_workloads/workload_planning/htcondor_job_submission.md
+++ b/documentation/htc_workloads/workload_planning/htcondor_job_submission.md
@@ -3,10 +3,10 @@ ospool:
   path: htc_workloads/workload_planning/htcondor_job_submission.md
 ---
 
-# Overview: Submit OSPool Jobs using HTCondor
+# Overview: Submit Jobs to the OSPool using HTCondor
 
 ## Purpose
-This guide discusses how to run jobs on the OSPool using HTCondor.
+This guide discusses the mechanics of creating and submitting jobs to the OSPool using HTCondor.
 
 ## OSPool Workflow Overview
 The process of running computational workflows on OSG resources follows the following outline: 
@@ -14,6 +14,7 @@ The process of running computational workflows on OSG resources follows the foll
 <img src="../../../assets/overview_htcondor_job_submission.png" class= "img-fluid"/>
 
 **Terminology:**
+
 - **Access point** is where you login and stage your data, executables/scripts, and software to use in jobs. <br>
 - **HTCondor** is a job scheduling software that will run your jobs out on the OSPool execution points. All jobs must be submitted to HTCondor to run out on the OSPool. <br>
 - The **Open Science Pool (OSPool)** is the set of resources your job runs on. It is composed of execution points, as well as other technologies, that compose the cpus, memory, and disk space that will run the computations of your jobs. 
@@ -144,7 +145,7 @@ To check on the status of your jobs in the queue, run the following command:
 The output of `condor_q` should look like this:
 -- Schedd: ap40.uw.osg-htc.org : <128.104.101.92:9618?... @ 04/14/23 15:35:17
 OWNER     BATCH_NAME     SUBMITTED   DONE   RUN    IDLE  TOTAL JOB_IDS
-Alice ID: 3606214   4/14 12:31      2     1      _      3 36062145.0-2
+Alice ID: 3606214       4/14 12:31      2     1       _      3 36062145.0-2
 
 3 jobs; 2 completed, 0 removed, 0 idle, 1 running, 0 held, 0 suspended
 ```

--- a/documentation/htc_workloads/workload_planning/roadmap.md
+++ b/documentation/htc_workloads/workload_planning/roadmap.md
@@ -70,7 +70,7 @@ Before submitting your own computational work, it is important to
 understand how HTCondor job submission works. The following guides show
 how to submit basic HTCondor jobs.
 
-- [Overview: Submit OSPool Jobs using HTCondor](../../../htc_workloads/workload_planning/htcondor_job_submission/)
+- [Overview: Submit Jobs to the OSPool using HTCondor](../../../htc_workloads/workload_planning/htcondor_job_submission/)
 
 ## 4. Test a First Job
 

--- a/documentation/overview/references/frequently-asked-questions.md
+++ b/documentation/overview/references/frequently-asked-questions.md
@@ -163,7 +163,7 @@ Every job submitted from an OSG-managed access point must be labeled with a Job 
 Jobs with single executions longer than 20 hours in tests on the OSPool should not be submitted, without self-checkpointing.  
 <br>
 <br>
-Details on how to specify +JobDurationCategory can be found in our <a href="https://portal.osg-htc.org/documentation/htc_workloads/workload_planning/htcondor_job_submission/">Overview: Submit OSPool Jobs using HTCondor</a> and <a href="https://portal.osg-htc.org/documentation/htc_workloads/workload_planning/roadmap/">Roadmap to HTC Workload Submission</a> guides. 
+Details on how to specify +JobDurationCategory can be found in our <a href="https://portal.osg-htc.org/documentation/htc_workloads/workload_planning/htcondor_job_submission/">Overview: Submit Jobs to the OSPool using HTCondor</a> and <a href="https://portal.osg-htc.org/documentation/htc_workloads/workload_planning/roadmap/">Roadmap to HTC Workload Submission</a> guides. 
 <br>
 </details>
 


### PR DESCRIPTION
Per https://opensciencegrid.atlassian.net/browse/RESFACIL-322.
Changed title so that the additional ¶ character doesn't take up its own "blank" line.