### PR TITLE
Refactoring Login and Registration guides

### DIFF
--- a/documentation/overview/account_setup/comanage-access.md
+++ b/documentation/overview/account_setup/comanage-access.md
@@ -44,7 +44,7 @@ To authenticate using this approach:
    ```
 
 2. Open your unique `https://` link in your web browser. 
-   With some terminals, you may be able to click on the link to open it.
+   When using some terminal applications, you may be able to click on the link to open it.
    Otherwise, copy the link and paste it into a web browser, and hit enter.  
 
 3. You will be redirected to a new page where you will be prompted to login using your institutional credentials. 

--- a/documentation/overview/account_setup/comanage-access.md
+++ b/documentation/overview/account_setup/comanage-access.md
@@ -18,7 +18,7 @@ To join and use the `uw.osg-htc.org` Access Points (`ap40.uw.osg-htc.org`), you 
 
 To request access to `ap40.uw.osg-htc.org`, submit an application using the following steps:
 
-1. To request an OSPool account, visit this account [registration page](https://registry.cilogon.org/registry/co_petitions/start/coef:211). You will be redirected to the CILogon sign in page. Select your institution and use your institutional credentials to login. You will use these credentials later to login so it is important to remember the institution you use at this step. 
+1. To request an OSPool account, visit this account [registration page](https://registry.cilogon.org/registry/co_petitions/start/coef:211). **OSG User School 2024 participants should use [this link](https://registry.cilogon.org/registry/co_petitions/start/coef:496).** You will be redirected to the CILogon sign in page. Select your institution and use your institutional credentials to login. You will use these credentials later to login so it is important to remember the institution you use at this step.
    
    
       <img src="../../../assets/ap7-images/cilogon.png" class= "img-fluid"/>
@@ -98,6 +98,16 @@ The process below describes how to upload a public key to the registration websi
 
 You can now log in to `ap40.uw.osg-htc.org` from the terminal, using `ssh username@ap40.uw.osg-htc.org`. When you log in, instead of being prompted with a web link, you should either authenticate automatically or be asked for your ssh key passphrase to complete logging in.
 
+## Known Issues
+
+* Existing Account
+	* Error message: `SORID "http://cilogon.org/serverA/users/20186" is already associated with EnvSource`
+	* Try logging into [COmanage](https://registry.cilogon.org/). If you can log in, 
+	email us with your name and we will add you to the appropriate group. 
+
+* Privacy enhancing plugins
+	* Error message: `Identifier (SORID) variable "REDIRECT_OIDC CLAIM sub" not set`
+	* We have seen this happen when a user has various "privacy enhancing" plugins installed in the browser and it blocks the necessary flow from fully happening. Try a different web browser without any plugins installed. 
 
 ## Get Help
 

--- a/documentation/overview/account_setup/comanage-access.md
+++ b/documentation/overview/account_setup/comanage-access.md
@@ -8,46 +8,17 @@ ospool:
 **This guide is for users who were notified by a member of the OSG team that they 
 will be using the `uw.osg-htc.org` Access Points.**
 
-To join and use the `uw.osg-htc.org` Access Points (`ap40.uw.osg-htc.org`), you will go through the following steps: 
-
-1. Apply for a `uw.osg-htc.org` Access Point account 
-2. Have your account approved by an OSG Team member
-3. Log in to `ap40.uw.osg-htc.org`
-
-## Request Access to `uw.osg-htc.org` Access Points
-
-To request access to `ap40.uw.osg-htc.org`, submit an application using the following steps:
-
-1. To request an OSPool account, visit this account [registration page](https://registry.cilogon.org/registry/co_petitions/start/coef:211). **OSG User School 2024 participants should use [this link](https://registry.cilogon.org/registry/co_petitions/start/coef:496).** You will be redirected to the CILogon sign in page. Select your institution and use your institutional credentials to login. You will use these credentials later to login so it is important to remember the institution you use at this step.
-   
-   
-      <img src="../../../assets/ap7-images/cilogon.png" class= "img-fluid"/>
-   
-   
-   If you have issues signing in using your institutional credentials, contact us at [support@osg-htc.org](mailto:support@osg-htc.org).
-
-
-2. Once you sign in, you will be redirected to the User Enrollment page. Click "Begin" and enter your name and email address in the following page. In many cases, this information will be automatically populated. If desired, it is possible to manually edit any information automatically filled in. Once you have entered your information, click "SUBMIT".
-
-
-      <img src="../../../assets/ap7-images/comanage-enrollment-form.png" class= "img-fluid"/>
-
-3. After submitting your application, you will receive an email from [registry@cilogon.org](mailto:registry@cilogon.org) to verify your email address. Click the link listed in the email to be redirected to a page confirm your invitation details. Click the "ACCEPT" button to complete this step.
-
-
-      <img src="../../../assets/ap7-images/comanage-email-verification-form.png" class= "img-fluid"/>
-   
-
-## Account Approval by a Research Computing Facilitator
-
-If a meeting has not already been scheduled with a Research Computing Facilitator, one of the facilitation team will contact you about arranging a short consultation. 
-
-Following the meeting, the Facilitator will approve your account and add your profile to any relevant OSG ‘project’ names. Once your account is ready, the Facilitator will email you with your account details including the 'username' you will use to log in to the `ap40.uw.osg-htc.org` access point. 
+> To use the `uw.osg-htc.org` Access Points (`ap40.uw.osg-htc.org`), 
+> you must have first registered and have your account approved
+> as described [here](../registration-and-login).
 
 ## Log in
 
-Once your account has been added to the `ap40.uw.osg-htc.org` access point, you will be able to log in using a terminal or SSH program. Logging in requires authenticating your credientials using one of two options: __web authentication__ or __SSH key pair authentication__. Additional information on this process will be provided during and/or following your discussion with a Research Computing Facilitator.
+To log in, you can authenticate using one of two methods:
 
+1. [Browser-based web authentication](#option-1-log-in-via-web-authentication) (requires access to web browser)
+
+2. [SSH key pair authentication](#option-2-log-in-via-ssh-key-pair-authentication) (requires uploading an SSH key)
 
 ### Option 1: Log in via Web Authentication
 
@@ -55,30 +26,43 @@ Logging in via web authentication requires no preparatory steps beyond having ac
 
 To authenticate using this approach: 
 
-1. Open a terminal and type `ssh username@ap40.uw.osg-htc.org`, being sure to replace `username` with your `uw.osg-htc.org` username. Upon hitting enter, the following text should appear with a unique, but similar, URL: 
+1. Open a terminal and enter the following command, 
+   being sure to replace `username` with your `uw.osg-htc.org` username:
+   
+   ```
+   ssh username@ap40.uw.osg-htc.org
+   ```
+   
+   Upon hitting enter, the following text should appear with a unique URL, similar to the one in the example below: 
+   
+   ```
+   Authenticate at
+   -----------------
+   https://cilogon.org/device/?user_code=FF4-ZX6-9LK
+   -----------------
+   Type 'Enter' when you authenticate.
+   ```
 
+2. Open your unique `https://` link in your web browser. 
+   With some terminals, you may be able to click on the link to open it.
+   Otherwise, copy the link and paste it into a web browser, and hit enter.  
 
-        Authenticate at
-        -----------------
-        https://cilogon.org/device/?user_code=FF4-ZX6-9LK
-        -----------------
-        Type 'Enter' when you authenticate.
+3. You will be redirected to a new page where you will be prompted to login using your institutional credentials. 
+   Once you have done so, a new page will appear with the following text: `"You have successfully approved the user code. Please return to your device for further instructions."`
 
-
-2. Copy the `https://` link, paste it into a web browser, and hit enter.  
-
-3. You will be redirected to a new page where you will be prompted to login using your institutional credentials. Once you have done so, a new page will appear with the following text: "You have successfully approved the user code. Please return to your device for further instructions."
-
-4. Return to your terminal, and type 'Enter' to complete the login process. 
+4. Return to your terminal, and press the 'Enter' key to complete the login process. 
 
 
 ### Option 2: Log in via SSH Key Pair Authentication
 
-It is also possible to authenticate using an SSH key pair, if you prefer. Logging in using SSH keys does not require access to an internet browser to log in into the OSG Access Point, `ap40.uw.osg-htc.org`. 
+It is also possible to authenticate using an SSH key pair, if you prefer. 
+Logging in using SSH keys does not require access to an internet browser.. 
 
-The process below describes how to upload a public key to the registration website. It assumes that a private/public key pair has already been generated. If you need to generate a key pair, see this [OSG guide](../generate-add-sshkey). 
+The process below describes how to upload a public key to the registration website. 
+It assumes that a private/public key pair has already been generated. 
+If you need to generate a key pair, see this [guide](../generate-add-sshkey). 
 
-1. Return to the [Registration Page](https://registry.cilogon.org/registry/auth/logout) and login using your institutional credentials if prompted.
+1. Return to the [Registration Page](https://registry.cilogon.org/registry/) and login using your institutional credentials, if prompted.
 
 2. Click your name at the top right. In the dropdown box, click "My Profile (OSG)" button.
 
@@ -96,7 +80,15 @@ The process below describes how to upload a public key to the registration websi
 
       <img src="../../../assets/ap7-images/ssh-key-list.png" class= "img-fluid"/>
 
-You can now log in to `ap40.uw.osg-htc.org` from the terminal, using `ssh username@ap40.uw.osg-htc.org`. When you log in, instead of being prompted with a web link, you should either authenticate automatically or be asked for your ssh key passphrase to complete logging in.
+You can now log in to `ap40.uw.osg-htc.org` from the terminal using the following command, 
+being sure to replace `username` with your `uw.osg-htc.org` username:
+   
+```
+ssh username@ap40.uw.osg-htc.org
+```
+
+When you run this command, you may be asked for your SSH key passphrase.
+Enter your corresponding passphrase and you should be logged in to `ap40.uw.osg-htc.org`.
 
 ## Known Issues
 

--- a/documentation/overview/account_setup/connect-access.md
+++ b/documentation/overview/account_setup/connect-access.md
@@ -3,33 +3,87 @@ ospool:
   path: overview/account_setup/connect-access.md
 ---
 
-# Log In to "OSG Connect" Access Points
+# Log In to `uc.osg-htc.org` Access Points
 
 **This guide is for users who were notified by a member of the OSG team that they 
 will be using the "OSG Connect" Access Points. Do not go through the steps of this 
 guide until advised to by a Research Computing Facilitator**
 
-To join and use the "OSG Connect" Access Points (`ap20.uc.osg-htc.org`, 
-`ap21.uc.osg-htc.org`), you will go through the following steps: 
+> To use the "OSG Connect" Access Points (`ap20.uc.osg-htc.org`, 
+> `ap21.uc.osg-htc.org`), you must have first registered and have your account approved
+> as described [here](../registration-and-login).
 
-1. Apply for an OSG Connect Access Point account 
-2. Have your account approved by an OSG Team member
-3. Generate an ssh key and add it to your web profile
-4. Log in to the appropriate Access Point
+* If this is your first time logging in using OSG Connect, you'll need to first [set up multi factor authentication](#add-multi-factor-authentication-to-your-web-profile).
 
-## Apply for an OSG Connect Access Point account 
+* If this is your first time logging in from your current device, 
+you'll need to [add an SSH key to your web profile](#add-a-public-ssh-key-to-your-web-profile).
 
-If prompted by a Research Computing Facilitator, you can apply for OSG Connect Access Points here: 
+* If you've already set up an SSH key on your current device, you are ready to [log in](#log-in)!
 
-[OSG Connect Account Request](https://www.osgconnect.net/signup)
+## Log In
 
-## Account Approval by a Research Computing Facilitator
+If you have recently [set up multi factor authentication](#add-multi-factor-authentication-to-your-web-profile)
+or [set up an SSH key for your current device](#add-a-public-ssh-key-to-your-web-profile), 
+please wait 15 minutes before trying to log in.
 
-If a meeting has not already been scheduled with a Research Computing Facilitator, one of the facilitation team will contact you about arranging a short consultation. 
+### For Mac, Linux, or newer versions of Windows
 
-Following the meeting, the Facilitator will approve your account and add your profile to 
-any relevant OSG ‘project’ names. Once your account is ready, the Facilitator will email 
-you with your account details. 
+Open a terminal and type the following command, where you replace `your_osg_connect_username` and `your_osg_login_node`
+with the appropriate values for your account: 
+
+    ssh your_osg_connect_username@your_osg_login_node
+
+It will ask for the passphrase for your ssh key (if you set one), then for 
+a "Verification code" which you should get by going to the TOTP client you 
+used to set up multi factor authentication. After entering the six digit 
+code, you should be logged in. 
+
+Note that when you are typing your passphrase and verification code, your typing will 
+NOT appear on the terminal, but the information is being entered! 
+
+> ### Finding your account information
+> 
+> Before you can connect, you will need to know your username and which login node your account is assigned to. 
+> You can find this information on your profile from the OSG Connect website.
+> 
+> 1. Go to www.osgconnect.net and sign in with your institution credentials that you used to request an account. 
+> 
+> 2. Click "Profile" in the top right corner.
+> 
+> 3. The box on the left side contains your login information. 
+>    The login node address should be listed in the top right of this box.
+>    The `UNIX User Name` on the left side of this box is your username.
+> 
+> ![Identify Login Node](/images/find_osgconnect_login_node.png "OSG Connect Profile")
+> 
+
+### For older versions of Windows
+
+On older versions of Windows, you can use the [Putty program](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) to log in. 
+
+<img src="/images/putty-screenshots.png" alt="PuTTY Intructions Screenshot">
+
+1. Open the `PutTTY` program. If necessary, you can download PuTTY from the website here [PuTTY download page](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
+
+2. Type the address of your assigned login node as the hostname (see "Determine which login node to use" above).
+
+3. In the left hand menu, click the "+" next to "SSH" to expand the menu.
+
+4. Click "Auth" in the "SSH" menu.
+
+5. Click "Browse" and specify the private key file you previously generated.
+
+6. Return to "Session".    
+&nbsp;&nbsp;&nbsp;&nbsp;a. Name your session    
+&nbsp;&nbsp;&nbsp;&nbsp;b. Save session for future use    
+
+7. Click "Open" to launch shell. Provide your ssh-key passphrase (created at Step 4 in PuTTYgen) when prompted to do so.
+
+8. When prompted for a "Verification Code", go to the TOTP client you used to set up 
+two-factor authentication, above, and enter the six digit code from the client into 
+your PuTTY terminal prompt. 
+
+The following video demonstrates the key generation and login process from the [Putty](https://www.youtube.com/watch?v=zk1uo1nA2HA&t=210s&ab_channel=OSG) 
 
 ## Add a public SSH key to your web profile
 
@@ -91,61 +145,3 @@ Once you have a TOTP client, configure it to be used with OSG Connect:
 **Important: after setting up multi-factor authentication using your TOTP client, you will 
 need to wait 15 minutes before logging in.**
 
-## Logging In
-
-After following the steps above to upload your key and set up multi factor authentication, once 
-about fifteen minutes have passed, you should be able to log in to OSG Connect. 
-
-### Determine which login node to use
-
-Before you can connect, you will need to know which login node your account is assigned to. You can find 
-this information on your profile from the OSG Connect website.
-
-1. Go to www.osgconnect.net and sign in with your institution credentials that you used to request an account. 
-
-2. Click "Profile" in the top right corner.
-
-3. The assigned login nodes are listed in the left side box. Make note of the address of 
-your assigned login node as you will use this to connect to OSG Connect.
-
-![Identify Login Node](/images/find_osgconnect_login_node.png "OSG Connect Profile")
-
-### For Mac, Linux, or newer versions of Windows
-
-Open a terminal and type in: 
-
-    ssh <your_osg_connect_username>@<your_osg_login_node>
-
-It will ask for the passphrase for your ssh key (if you set one), then for 
-a "Verification code" which you should get by going to the TOTP client you 
-used to set up two factor authentication above. After entering the six digit 
-code, you should be logged in. 
-
-Note that when you are typing your passphrase and verification code, your typing will 
-NOT appear on the terminal, but the information is being entered! 
-
-### For older versions of Windows
-
-On older versions of Windows, you can use the [Putty program](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) to log in. 
-
-<img src="/images/putty-screenshots.png" alt="PuTTY Intructions Screenshot">
-
-1. Open the `PutTTY` program. If necessary, you can download PuTTY from the website here [PuTTY download page](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
-
-2. Type the address of your assigned login node as the hostname (see "Determine which login node to use" above).
-
-3. In the left hand menu, click the "+" next to "SSH" to expand the menu.
-
-4. Click "Auth" in the "SSH" menu.
-
-5. Click "Browse" and specify the private key file you saved in step 5 above.
-
-6. Return to "Session".    
-&nbsp;&nbsp;&nbsp;&nbsp;a. Name your session    
-&nbsp;&nbsp;&nbsp;&nbsp;b. Save session for future use     
-7. Click "Open" to launch shell. Provide your ssh-key passphrase (created at Step 4 in PuTTYgen) when prompted to do so.
-8. When prompted for a "Verification Code", go to the TOTP client you used to set up 
-two-factor authentication, above, and enter the six digit code from the client into 
-your PuTTY terminal prompt. 
-
-The following video demonstrates the key generation and login process from the [Putty](https://www.youtube.com/watch?v=zk1uo1nA2HA&t=210s&ab_channel=OSG) 

--- a/documentation/overview/account_setup/connect-access.md
+++ b/documentation/overview/account_setup/connect-access.md
@@ -73,9 +73,11 @@ On older versions of Windows, you can use the [Putty program](https://www.chiark
 
 5. Click "Browse" and specify the private key file you previously generated.
 
-6. Return to "Session".    
-&nbsp;&nbsp;&nbsp;&nbsp;a. Name your session    
-&nbsp;&nbsp;&nbsp;&nbsp;b. Save session for future use    
+6. Return to "Session". Then   
+
+   * Name your session 
+
+   * Save session for future use    
 
 7. Click "Open" to launch shell. Provide your ssh-key passphrase (created at Step 4 in PuTTYgen) when prompted to do so.
 

--- a/documentation/overview/account_setup/connect-access.md
+++ b/documentation/overview/account_setup/connect-access.md
@@ -46,7 +46,7 @@ NOT appear on the terminal, but the information is being entered!
 > Before you can connect, you will need to know your username and which login node your account is assigned to. 
 > You can find this information on your profile from the OSG Connect website.
 > 
-> 1. Go to www.osgconnect.net and sign in with your institution credentials that you used to request an account. 
+> 1. Go to [https://www.osgconnect.net](https://www.osgconnect.net) and sign in with your institution credentials that you used to request an account. 
 > 
 > 2. Click "Profile" in the top right corner.
 > 

--- a/documentation/overview/account_setup/registration-and-login.md
+++ b/documentation/overview/account_setup/registration-and-login.md
@@ -43,7 +43,7 @@ for an account on a specific OSPool Access Point. The current default are
 
 To register for the `ap40.uw.osg-htc.org` access point, submit an application using the following steps:
 
-1. Visit this account [registration page](https://registry.cilogon.org/registry/co_petitions/start/coef:211). **OSG User School 2024 participants should use [this link](https://registry.cilogon.org/registry/co_petitions/start/coef:496).** You will be redirected to the CILogon sign in page. Select your institution and use your institutional credentials to login. You will use these credentials later to login so it is important to remember the institution you use at this step.
+1. Visit this account [registration page](https://registry.cilogon.org/registry/co_petitions/start/coef:211). You will be redirected to the CILogon sign in page. Select your institution and use your institutional credentials to login. You will use these credentials later to login so it is important to remember the institution you use at this step.
    
    
       <img src="../../../assets/ap7-images/cilogon.png" class= "img-fluid"/>

--- a/documentation/overview/account_setup/registration-and-login.md
+++ b/documentation/overview/account_setup/registration-and-login.md
@@ -3,9 +3,7 @@ ospool:
   path: overview/account_setup/registration-and-login.md
 ---
 
-Start Here: Overview of Requesting OSPool Access
-====================================
-
+## Start Here: Overview of Requesting OSPool Access
 
 The major steps to get started on the OSPool are: 
 
@@ -41,8 +39,44 @@ Before or during the orientation meeting, you will be prompted to register
 for an account on a specific OSPool Access Point. The current default are
 `uw.osg-htc.org` Access Points. 
 
-You will be directed to follow instructions on [this page](../ap7-access) to register 
-for an account. 
+### Register for `uw.osg-htc.org` Access Points
+
+To register for the `ap40.uw.osg-htc.org` access point, submit an application using the following steps:
+
+1. Visit this account [registration page](https://registry.cilogon.org/registry/co_petitions/start/coef:211). **OSG User School 2024 participants should use [this link](https://registry.cilogon.org/registry/co_petitions/start/coef:496).** You will be redirected to the CILogon sign in page. Select your institution and use your institutional credentials to login. You will use these credentials later to login so it is important to remember the institution you use at this step.
+   
+   
+      <img src="../../../assets/ap7-images/cilogon.png" class= "img-fluid"/>
+   
+   
+   If you have issues signing in using your institutional credentials, contact us at [support@osg-htc.org](mailto:support@osg-htc.org).
+
+
+2. Once you sign in, you will be redirected to the User Enrollment page. Click "Begin" and enter your name and email address in the following page. In many cases, this information will be automatically populated. If desired, it is possible to manually edit any information automatically filled in. Once you have entered your information, click "SUBMIT".
+
+
+      <img src="../../../assets/ap7-images/comanage-enrollment-form.png" class= "img-fluid"/>
+
+3. After submitting your application, you will receive an email from [registry@cilogon.org](mailto:registry@cilogon.org) to verify your email address. Click the link listed in the email to be redirected to a page confirm your invitation details. Click the "ACCEPT" button to complete this step.
+
+
+      <img src="../../../assets/ap7-images/comanage-email-verification-form.png" class= "img-fluid"/>
+   
+### Register for `uc.osg-htc.org` Access Points
+
+You can register for OSG Connect Access Points here: 
+
+[OSG Connect Account Registration](https://www.osgconnect.net/signup)
+
+**Only do this if you have been instructed to do so by a Research Computing Facilitator!**
+
+## Account Approval by a Research Computing Facilitator
+
+If a meeting has not already been scheduled with a Research Computing Facilitator, one of the facilitation team will contact you about arranging a short consultation. 
+
+Following the meeting, the Facilitator will approve your account and add your profile to 
+any relevant OSG ‘project’ names. Once your account is ready, the Facilitator will email 
+you with your account details. 
 
 ## Log In
 
@@ -54,17 +88,17 @@ Follow the instructions below to learn how to log in to you OSPool Access Point.
 **Accounts for all new users are created on `uw.osg-htc.org` Access Points unless otherwise specified.** 
 
 <details>
-<summary>Log In to "uw.osg-htc.org" Access Points (e.g., ap40.uw.osg-htc.org)</summary>
+<summary>Log In to <code>uw.osg-htc.org</code> Access Points (e.g., <code>ap40.uw.osg-htc.org</code>)</summary>
 <br>
-If your account is on the uw.osg-htc.org Access Points (e.g., accounts on ap40.uw.osg-htc.org), follow instructions in this guide for logging in:
-<a href="https://portal.osg-htc.org/documentation/overview/account_setup/ap7-access/">Log In to uw.osg-htc.org Access Points</a>
+If your account is on the <code>uw.osg-htc.org</code> Access Points (e.g., accounts on <code>ap40.uw.osg-htc.org</code>), follow instructions in this guide for logging in:
+<a href="https://portal.osg-htc.org/documentation/overview/account_setup/comanage-access/">Log In to <code>uw.osg-htc.org</code> Access Points</a>
 </details>
 
 <details>
-<summary>Log In to "OSG Connect" Access Points (e.g., ap20.uc.osg-htc.org)</summary>
+<summary>Log In to <code>uc.osg-htc.org</code> Access Points (e.g., <code>ap20.uc.osg-htc.org</code>)</summary>
 <br>
-If your account is on the OSG Connect Access points (e.g., accounts on ap20.uc.osg-htc.org, ap21.uc.osg-htc.org), follow instructions in this guide for logging in:
-<a href="https://portal.osg-htc.org/documentation/overview/account_setup/connect-access/">Log In to OSG Connect Access Points</a>
+If your account is on the <code>uc.osg-htc.org</code> Access Points (e.g., accounts on <code>ap20.uc.osg-htc.org</code>, <code>ap21.uc.osg-htc.org</code>), follow instructions in this guide for logging in:
+<a href="https://portal.osg-htc.org/documentation/overview/account_setup/connect-access/">Log In to <code>uc.osg-htc.org</code> Access Points</a>
 </details>
 
 

--- a/documentation/overview/account_setup/registration-and-login.md
+++ b/documentation/overview/account_setup/registration-and-login.md
@@ -39,6 +39,9 @@ Before or during the orientation meeting, you will be prompted to register
 for an account on a specific OSPool Access Point. The current default are
 `uw.osg-htc.org` Access Points. 
 
+***Please do not register for an Access Point until you have been instructed
+to do so by a Research Computing Facilitator!***
+
 ### Register for `uw.osg-htc.org` Access Points
 
 To register for the `ap40.uw.osg-htc.org` access point, submit an application using the following steps:


### PR DESCRIPTION
Previously, the "Log In" guides started with how to apply for and complete the account registration process. 

* Moved the how-to-apply-and-register stuff to the registration info page.
* Added warning and link-to-registration-info to the Log In guides.
* Restructured Log In guides in order of most-often-used to least-often-used.
* Other minor changes while editing/reviewing

Recommend that you view the full files and assessing the structure before reviewing specific changes.