### PR TITLE
Updated Container Documentation Language

### DIFF
--- a/documentation/htc_workloads/using_software/containers-docker.md
+++ b/documentation/htc_workloads/using_software/containers-docker.md
@@ -26,6 +26,11 @@ Docker image from the Docker Hub.
 If you already have an existing Docker container image, skip
 to [Preparing Docker Containers for HTCondor Jobs](#preparing-docker-containers-for-htcondor-jobs). Otherwise, continue reading. 
 
+!!! warning "Warning: Build Docker containers on your local machine"
+
+    The steps below must be run **on your local computer**, not on the OSPool Access Point.  
+    Docker is not available on the Access Point, and these commands will fail if run there.
+
 ### Identify Components
 
 What software do you want to install? Make sure that you have either the source 
@@ -41,7 +46,7 @@ There are two main methods for generating your own container image.
 2. Editing the default image using local Docker
 
 We recommend the first option, as it is more reproducible, but the second option 
-can be useful for troubleshooting or especially tricky installs. 
+can be useful for troubleshooting or especially tricky installs.
 
 #### Dockerfile
 
@@ -131,6 +136,12 @@ the best experience on the OSpool.
 
 ### Convert Docker containers on Docker Hub or online
 
+!!! note "Note: Complete on the AP"
+
+    The steps below should be completed on the OSPool Access Point. As we will
+    prepare our Docker container to be converted to an Apptainer container and ran
+    on the OSPool infrastructure. 
+
 If the Docker container you want to use is online, on a site like Docker Hub, you can 
 log in to your Access Point and run a single command to convert it to a `.sif` image: 
 
@@ -140,6 +151,12 @@ Where the path at the end of the command is customized to be the container image
 you want to use. 
 
 ### Convert Docker containers on your computer
+
+!!! note "Note: On Your Computer"
+
+    The steps below should be completed on the OSPool Access Point. As we will
+    prepare our Docker container to be converted to an Apptainer container and ran
+    on the OSPool infrastructure. 
 
 If you have built a Docker image on your own host, you can save it as a 
 tar file and then convert it to an Apptainer/Singularity SIF image. First
@@ -152,6 +169,12 @@ find the image id:
 Using the image id, save the image to a tar file:
 
     $ docker save f1e7972c55bc -o my-container.tar
+
+!!! note "Note: On The Access Point"
+
+    The steps below should be completed on the OSPool Access Point. As we will
+    prepare our Docker container to be converted to an Apptainer container and ran
+    on the OSPool infrastructure. 
 
 Transfer `my-container.tar` to the OSPool access point, and use
 Apptainer to convert it to a SIF image:

--- a/documentation/htc_workloads/using_software/containers-singularity.md
+++ b/documentation/htc_workloads/using_software/containers-singularity.md
@@ -47,10 +47,16 @@ The best candidates for you will be containers that have "osgvo" in the name.
 
 ### Apptainer/Singularity Build
 
-If you are building an image for the first time, the temporary cache directory of the apptainer image needs to be defined. The following commands define the cache location of the apptainer image to be built. Please run the commands in the terminal of your access point.
+When you are building an Apptainer container image, the temporary cache directory of the apptainer image needs to be defined. The following commands define the cache location of the apptainer image to be built. Please run the commands in the terminal of your access point.
+
+!!! danger "Run These Commands Each Time Before Proceeding"
+
+    Building Apptainer containers on the Access Point without first running the commands below 
+    places excessive strain on shared storage resources and **violates OSPool usage policies**. 
+    Failure to follow these steps may result in restricted access to the system.
 
 ```
-$mkdir $HOME/tmp
+$mkdir -p $HOME/tmp
 $export TMPDIR=$HOME/tmp
 $export APPTAINER_TMPDIR=$HOME/tmp
 $export APPTAINER_CACHEDIR=$HOME/tmp

--- a/documentation/htc_workloads/using_software/containers-singularity.md
+++ b/documentation/htc_workloads/using_software/containers-singularity.md
@@ -14,6 +14,7 @@ own Apptainer/Singularity container "image" (the blueprint for the container).
 
 If there is an existing Docker container or Apptainer/Singularity container with 
 the software you need, you can proceed with using these options to submit a job. 
+
 * [See OSPool-provided containers here](../available-containers-list/)
 * [Using an existing Docker container](../containers-docker/)
 * [Using an existing Apptainer/Singularity container](#using-singularity-or-apptainer-images-in-an-htcondor-job)


### PR DESCRIPTION
Made changes to the [/htc_workloads/using_software/containers-docker/](https://portal.osg-htc.org/documentation/htc_workloads/using_software/containers-docker/) page:

- Added notes and warnings on when to run commands on the AP vs the user’s computer

Made changes to [/htc_workloads/using_software/containers-singularity/](https://portal.osg-htc.org/documentation/htc_workloads/using_software/containers-singularity/)  page:
- Added “danger”-style warning to remind users to run the commands to change the Apptainer temporary cache. 
- Changed first command from 

    `mkdir $HOME/tmp`
    to:

    `mkdir -p $HOME/tmp`

    to allow for repeated use of the commands, as export commands should be ran each time a user builds the container

- Updated language slightly to imply that these commands must be reran each time a user builds a container. This prevents them from thinking it’s a one-time command for subsequent builds. 

