### PR TITLE
Updating submodule reference for tutorial-dagman-intermediate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	url = https://github.com/OSGConnect/tutorial-spills-R
 [submodule "documentation/tutorials/tutorial-dagman-intermediate"]
 	path = documentation/tutorials/tutorial-dagman-intermediate
-	url = https://github.com/OSGConnect/tutorial-dagman-intermediate.git
+	url = https://github.com/osg-htc/tutorial-dagman-intermediate.git
 [submodule "documentation/tutorials/tutorial-fastqc"]
 	path = documentation/tutorials/tutorial-fastqc
 	url = https://github.com/OSGConnect/tutorial-fastqc


### PR DESCRIPTION
Previewed locally - seems to have worked as intended.

Commands I ran:

```
vi .gitmodules  # replace repo URL for this tutorial
git submodule update --init --remote --recursive documentation/tutorials/tutorial-dagman-intermediate
git pull --recurse-submodules
# test with local preview
git add .gitmodules documentation/tutorials/tutorial-dagman-intermediate
git commit
```

According to `git status`, I had deleted some of the local submodule files.
I think this was because I specified the `submodule update` to only apply to the desired tutorial. 
I just didn't `git add` those changes.
Then, after I committed, I ran a `git restore ./*` command and everything looked correct then.