### PR TITLE
Removed OSDF locations for containers

### DIFF
--- a/documentation/htc_workloads/using_software/available-containers-list.md
+++ b/documentation/htc_workloads/using_software/available-containers-list.md
@@ -19,30 +19,15 @@ directly in your jobs or as base images if you want to define your own.
     Debian 12 base image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__debian__12.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/debian:12</span><br>
     <br>[Project Website](https://debian.org/)<br>
     <br>[Container Definition](https://github.com/osg-htc/htc-images)<br>
 
-??? info "EL 7 (htc/centos:7)"
-    Enterprise Linux (CentOS) 7 base image
-    <br>
-    <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__centos__7.sif</span><br>
-    CVMFS Locations:<br>
-    <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/centos:7</span><br>
-    <br>[Project Website](https://www.centos.org/)<br>
-    <br>[Container Definition](https://github.com/opensciencegrid/osgvo-el7)<br>
-
 ??? info "Rocky 8 (htc/rocky:8)"
     Rocky Linux 8 base image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__rocky__8.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/rocky:8</span><br>
     <br>[Project Website](https://rockylinux.org/)<br>
@@ -52,8 +37,6 @@ directly in your jobs or as base images if you want to define your own.
     Rocky Linux 8 / CUDA 11.0.3 image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__rocky__8-cuda-11.0.3.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/rocky:8-cuda-11.0.3</span><br>
     <br>[Project Website](https://rockylinux.org/)<br>
@@ -63,19 +46,15 @@ directly in your jobs or as base images if you want to define your own.
     Rocky Linux 9 base image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__rocky__9.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/rocky:9</span><br>
     <br>[Project Website](https://rockylinux.org/)<br>
     <br>[Container Definition](https://github.com/osg-htc/htc-images)<br>
 
-??? info "Rocky 9 / CUDA 2.6.0 (htc/rocky:9-cuda-12.6.0)"
+??? info "Rocky 9 / CUDA 12.6.0 (htc/rocky:9-cuda-12.6.0)"
     Rocky Linux 9 / CUDA 12.6.0 image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__rocky__9-cuda-12.6.0.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/rocky:9-cuda-12.6.0</span><br>
     <br>[Project Website](https://rockylinux.org/)<br>
@@ -85,8 +64,6 @@ directly in your jobs or as base images if you want to define your own.
     Ubuntu 20.04 (Focal) base image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__ubuntu__20.04.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/ubuntu:20.04</span><br>
     <br>[Project Website](https://www.ubuntu.com)<br>
@@ -96,8 +73,6 @@ directly in your jobs or as base images if you want to define your own.
     Ubuntu 22.04 (Jammy Jellyfish) base image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__ubuntu__22.04.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/ubuntu:22.04</span><br>
     <br>[Project Website](https://www.ubuntu.com)<br>
@@ -107,8 +82,6 @@ directly in your jobs or as base images if you want to define your own.
     Ubuntu 24.04 (Nobel Numbat) base image
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__ubuntu__24.04.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/ubuntu:24.04</span><br>
     <br>[Project Website](https://www.ubuntu.com)<br>
@@ -121,8 +94,6 @@ directly in your jobs or as base images if you want to define your own.
     Tensorflow image from the Tensorflow project, with OSG additions
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__tensorflow__2.15.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/tensorflow:2.15</span><br>
     <br>[Project Website](https://www.tensorflow.org/)<br>
@@ -132,8 +103,6 @@ directly in your jobs or as base images if you want to define your own.
     scikit-learn, configured for execution on OSG
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__scikit-learn__1.3.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/scikit-learn:1.3</span><br>
     <br>[Project Website](https://scikit-learn.org/)<br>
@@ -146,11 +115,6 @@ directly in your jobs or as base images if you want to define your own.
     Ubuntu based image with Julia
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-julia__1.0.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-julia__1.5.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-julia__1.7.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-julia__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-julia:1.0.3</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-julia:1.5.3</span><br>
@@ -163,8 +127,6 @@ directly in your jobs or as base images if you want to define your own.
     Ubuntu based image with Julia
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/m8zeng__julia-packages__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/m8zeng/julia-packages:latest</span><br>
     <br>[Project Website](https://julialang.org/)<br>
@@ -174,15 +136,6 @@ directly in your jobs or as base images if you want to define your own.
     This is the Matlab runtime component you can use to execute compiled Matlab codes
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2018b.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2019a.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2019b.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2020a.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2020b.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2021b.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2022b.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-matlab-runtime__R2023a.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-matlab-runtime:R2018b</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-matlab-runtime:R2019a</span><br>
@@ -199,8 +152,6 @@ directly in your jobs or as base images if you want to define your own.
     This is the Matlab runtime component you can use to execute compiled Matlab codes
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__matlab-runtime__R2023a.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/matlab-runtime:R2023a</span><br>
     <br>[Project Website](https://www.mathworks.com/products/compiler/matlab-runtime.html)<br>
@@ -210,10 +161,6 @@ directly in your jobs or as base images if you want to define your own.
     Example for building R images
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-r__3.5.0.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-r__4.0.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-r__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-r:3.5.0</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-r:4.0.2</span><br>
@@ -225,8 +172,6 @@ directly in your jobs or as base images if you want to define your own.
     Example for building R images
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/clkwisconsin__spacetimer__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/clkwisconsin/spacetimer:latest</span><br>
     <br>[Project Website](https://www.r-project.org/)<br>
@@ -239,68 +184,6 @@ directly in your jobs or as base images if you want to define your own.
     Base software environment for XENONnT, including Python 3.6 and data management tools
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2020.11.06.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2020.11.25.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2020.12.21.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2020.12.23.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.01.04.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.01.06.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.01.11.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.04.18.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.05.04.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.06.25.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.07.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.08.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.08.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.10.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.10.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.10.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.10.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.10.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.11.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.11.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.11.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.11.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.11.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.11.6.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.12.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.12.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2021.12.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.01.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.01.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.01.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.02.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.02.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.02.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.02.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.03.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.03.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.03.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.03.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.04.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.04.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.04.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.05.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.05.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.06.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.06.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.06.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.06.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.06.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.06.6.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.07.27.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.09.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__2022.11.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__add_latex.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__gpu.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__latex_test3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__py38.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__stable.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__straxen_0-13-1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__straxen_v100.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__switch_deployhq_user.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-xenon__upgrade-boost.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-xenon:2020.11.06</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-xenon:2020.11.25</span><br>
@@ -370,69 +253,6 @@ directly in your jobs or as base images if you want to define your own.
     Base software environment for XENONnT, including Python 3.6 and data management tools
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2020.11.06.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2020.11.25.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2020.12.21.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2020.12.23.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2020.12.24.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.01.04.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.01.06.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.01.11.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.04.18.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.05.04.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.06.25.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.07.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.08.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.08.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.10.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.10.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.10.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.10.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.10.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.11.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.11.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.11.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.11.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.11.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.11.6.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.12.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.12.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2021.12.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.01.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.01.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.01.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.02.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.02.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.02.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.02.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.03.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.03.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.03.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.03.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.04.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.04.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.04.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.05.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.05.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.06.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.06.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.06.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.06.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.06.5.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.06.6.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.07.27.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.09.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__2022.11.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__add_latex.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__gpu.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__latex_test3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__py38.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__stable.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__straxen_v100.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__switch_deployhq_user.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__testing.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__base-environment__upgrade-boost.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/xenonnt/base-environment:2020.11.06</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/xenonnt/base-environment:2020.11.25</span><br>
@@ -503,8 +323,6 @@ directly in your jobs or as base images if you want to define your own.
     Base software environment for XENONnT, including Python 3.6 and data management tools
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/xenonnt__osg_dev__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/xenonnt/osg_dev:latest</span><br>
     <br>[Project Website](http://www.xenon1t.org/)<br>
@@ -517,8 +335,6 @@ directly in your jobs or as base images if you want to define your own.
     A software package for animal pose estimation
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__deeplabcut__3.0.0rc4.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/deeplabcut:3.0.0rc4</span><br>
     <br>[Project Website](https://www.mackenziemathislab.org/deeplabcut)<br>
@@ -528,12 +344,6 @@ directly in your jobs or as base images if you want to define your own.
     A software package for the analysis and visualization of structural and functional neuroimaging data from cross-sectional or longitudinal studies
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-freesurfer__6.0.0.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-freesurfer__6.0.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-freesurfer__7.0.0.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-freesurfer__7.1.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-freesurfer__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-freesurfer:6.0.0</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-freesurfer:6.0.1</span><br>
@@ -543,14 +353,19 @@ directly in your jobs or as base images if you want to define your own.
     <br>[Project Website](https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferWiki)<br>
     <br>[Container Definition](https://github.com/opensciencegrid/osgvo-freesurfer)<br>
 
+??? info "FreeSurfer (htc/freesurfer:8.1.0)"
+    A software package for the analysis and visualization of structural and functional neuroimaging data from cross-sectional or longitudinal studies
+    <br>
+    <br>
+    CVMFS Locations:<br>
+    <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/freesurfer:8.1.0</span><br>
+    <br>[Project Website](https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferWiki)<br>
+    <br>[Container Definition](https://github.com/opensciencegrid/osgvo-freesurfer)<br>
+
 ??? info "GROMACS (opensciencegrid/osgvo-gromacs)"
     A versatile package to perform molecular dynamics, i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles.
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-gromacs__2018.4.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-gromacs__2020.2.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-gromacs__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-gromacs:2018.4</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-gromacs:2020.2</span><br>
@@ -562,8 +377,6 @@ directly in your jobs or as base images if you want to define your own.
     A versatile package to perform molecular dynamics, i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles. This is a GPU enabled version.
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-gromacs-gpu__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-gromacs-gpu:latest</span><br>
     <br>[Project Website](http://www.gromacs.org/)<br>
@@ -573,8 +386,6 @@ directly in your jobs or as base images if you want to define your own.
     Gromacs 2023.4 for use on OSG
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__gromacs__2023.4.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/gromacs:2023.4</span><br>
     <br>[Project Website](https://www.gromacs.org/)<br>
@@ -584,8 +395,6 @@ directly in your jobs or as base images if you want to define your own.
     Gromacs 2024.2 for use on OSG
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__gromacs__2024.2.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/gromacs:2024.2</span><br>
     <br>[Project Website](https://www.gromacs.org/)<br>
@@ -595,8 +404,6 @@ directly in your jobs or as base images if you want to define your own.
     Minimal image - used for testing
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__minimal__0.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/minimal:0</span><br>
     <br>[Project Website](https://osg-htc.org/)<br>
@@ -606,8 +413,6 @@ directly in your jobs or as base images if you want to define your own.
     A rich ecosystem of tools and libraries extends PyTorch and supports development in computer vision, NLP and more.
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/htc__pytorch__2.3.1-cuda11.8.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/htc/pytorch:2.3.1-cuda11.8</span><br>
     <br>[Project Website](https://pytorch.org/)<br>
@@ -617,9 +422,6 @@ directly in your jobs or as base images if you want to define your own.
     A suite for first-principles electronic-structure calculations and materials modeling
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-quantum-espresso__6.6.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-quantum-espresso__6.8.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-quantum-espresso:6.6</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-quantum-espresso:6.8</span><br>
@@ -630,8 +432,6 @@ directly in your jobs or as base images if you want to define your own.
     General purpose classical simulation package. It can be used for the simulation of molecules in gases, fluids, zeolites, aluminosilicates, metal-organic frameworks, carbon nanotubes and external fields.
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__osgvo-raspa2__2.0.41.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-raspa2:2.0.41</span><br>
     <br>[Project Website](https://github.com/iraspa/RASPA2)<br>
@@ -641,9 +441,6 @@ directly in your jobs or as base images if you want to define your own.
     TensorFlow image (CPU only)
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__tensorflow__2.3.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__tensorflow__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow:2.3</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow:latest</span><br>
@@ -654,8 +451,6 @@ directly in your jobs or as base images if you want to define your own.
     TensorFlow image (CPU only)
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/rynge__tensorflow-cowsay__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/rynge/tensorflow-cowsay:latest</span><br>
     <br>[Project Website](https://www.tensorflow.org/)<br>
@@ -665,8 +460,6 @@ directly in your jobs or as base images if you want to define your own.
     TensorFlow image (CPU only)
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/jiahe58__tensorflow__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/jiahe58/tensorflow:latest</span><br>
     <br>[Project Website](https://www.tensorflow.org/)<br>
@@ -676,10 +469,6 @@ directly in your jobs or as base images if you want to define your own.
     TensorFlow image with GPU support
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__tensorflow-gpu__2.2-cuda-10.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__tensorflow-gpu__2.3-cuda-10.1.sif</span><br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/opensciencegrid__tensorflow-gpu__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow-gpu:2.2-cuda-10.1</span><br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/opensciencegrid/tensorflow-gpu:2.3-cuda-10.1</span><br>
@@ -691,8 +480,6 @@ directly in your jobs or as base images if you want to define your own.
     TensorFlow image with GPU support
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/efajardo__astroflow__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/efajardo/astroflow:latest</span><br>
     <br>[Project Website](https://www.tensorflow.org/)<br>
@@ -702,8 +489,6 @@ directly in your jobs or as base images if you want to define your own.
     TensorFlow image with GPU support
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/ssrujanaa__catsanddogs__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/ssrujanaa/catsanddogs:latest</span><br>
     <br>[Project Website](https://www.tensorflow.org/)<br>
@@ -713,8 +498,6 @@ directly in your jobs or as base images if you want to define your own.
     TensorFlow image with GPU support
     <br>
     <br>
-    OSDF Locations:<br>
-    <span style="white-space: nowrap">osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/weiphy__skopt__latest.sif</span><br>
     CVMFS Locations:<br>
     <span style="white-space: nowrap">/cvmfs/singularity.opensciencegrid.org/weiphy/skopt:latest</span><br>
     <br>[Project Website](https://www.tensorflow.org/)<br>

--- a/scripts/container-list/update-container-list
+++ b/scripts/container-list/update-container-list
@@ -115,9 +115,9 @@ def main():
         details = entry['description'] + "\n<br>\n<br>\n"
 
         # osdf
-        details += "OSDF Locations:<br>\n"
-        for tag in sorted(entry['tags']):
-            details += '<span style="white-space: nowrap">{}</span><br>\n'.format("osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/" + sif_file(entry["identifier"], tag))
+        #details += "OSDF Locations:<br>\n"
+        #for tag in sorted(entry['tags']):
+        #    details += '<span style="white-space: nowrap">{}</span><br>\n'.format("osdf:///ospool/uc-shared/public/OSG-Staff/images/repo/x86_64/" + sif_file(entry["identifier"], tag))
 
         # cvmfs
         details += "CVMFS Locations:<br>\n"


### PR DESCRIPTION
As part of the 2025 migration, we are removing the OSDF origin for these images. This used to be a fallback location, and had issues with static locations and containers updates (not immutable as required by OSDF). Images will still be available via CVMFS.